### PR TITLE
Remove missing parsing files

### DIFF
--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -48,7 +48,7 @@ find_package(pybind11 REQUIRED)
 include_directories(thirdparty)
 include_directories(${CMAKE_INSTALL_PREFIX}/include)
 
-pybind11_add_module(mamba_api py_interface.cpp solver.cpp parsing.cpp thirdparty/simdjson/simdjson.cpp)
+pybind11_add_module(mamba_api py_interface.cpp solver.cpp thirdparty/simdjson/simdjson.cpp)
 
 target_link_libraries(mamba_api PRIVATE ${LibSolv_LIBRARIES})
 


### PR DESCRIPTION
It looks to me like f649d57d21d1b2da95c635fff22c19e44f11af10 removed parsing.cpp but forgot to remove it from the CMake file?  So this PR fixes that I *think*.  Or at the very least, if I make this small change mamba goes from un-buildable to buildable...