### PR TITLE
Add check to allow empty arguments to mamba

### DIFF
--- a/mamba/mamba.py
+++ b/mamba/mamba.py
@@ -61,15 +61,15 @@ banner = """
              /  /   \\_/   \\_/   \\_/   \\    o \\__,
             / _/                       \\_____/  `
             |/
-        ███╗   ███╗ █████╗ ███╗   ███╗██████╗  █████╗ 
+        ███╗   ███╗ █████╗ ███╗   ███╗██████╗  █████╗
         ████╗ ████║██╔══██╗████╗ ████║██╔══██╗██╔══██╗
         ██╔████╔██║███████║██╔████╔██║██████╔╝███████║
         ██║╚██╔╝██║██╔══██║██║╚██╔╝██║██╔══██╗██╔══██║
         ██║ ╚═╝ ██║██║  ██║██║ ╚═╝ ██║██████╔╝██║  ██║
         ╚═╝     ╚═╝╚═╝  ╚═╝╚═╝     ╚═╝╚═════╝ ╚═╝  ╚═╝
-                          
+
         Supported by @QuantStack
-    
+
         GitHub:  https://github.com/QuantStack/mamba
         Twitter: https://twitter.com/QuantStack
 
@@ -374,7 +374,7 @@ def main(*args, **kwargs):
 
     args = tuple(ensure_text_type(s) for s in args)
 
-    if args[1] == 'env' and args[2] == 'create':
+    if len(args) > 2 and args[1] == 'env' and args[2] == 'create':
         # special handling for conda env create!
         from mamba import mamba_env
         return mamba_env.main()


### PR DESCRIPTION
Currently if one simply does ``mamba``, the result is an ``IndexError: tuple index out of range``.  Regular conda instead yields the equivalent of ``conda --help``.  I suspect this is just a bug, so this PR does what I think is the natural fix to ensure the standard conda behavior if no argument is given.