### PR TITLE
Add the required neutered_specs arg to PrefixSupport calls

### DIFF
--- a/mamba/mamba.py
+++ b/mamba/mamba.py
@@ -150,11 +150,12 @@ def to_txn(specs, prefix, to_link, to_unlink, index=None):
                                                           force_reinstall=context.force_reinstall)
 
     pref_setup = PrefixSetup(
-        target_prefix = prefix,
-        unlink_precs  = unlink_precs,
-        link_precs    = link_precs,
-        remove_specs  = [],
-        update_specs  = specs
+        target_prefix  = prefix,
+        unlink_precs   = unlink_precs,
+        link_precs     = link_precs,
+        remove_specs   = [],
+        update_specs   = specs,
+        neutered_specs = ()
     )
 
     conda_transaction = UnlinkLinkTransaction(pref_setup)
@@ -200,6 +201,7 @@ def remove(args, parser):
                 link_precs=(),
                 remove_specs=(),
                 update_specs=(),
+                neutered_specs=(),
             )
             txn = UnlinkLinkTransaction(stp)
             handle_txn(txn, prefix, args, False, True)


### PR DESCRIPTION
Fixes #56 

I simply added `neutered_specs` args to the `conda.core.link.PrefixSupport` calls.

**To test** (using `continuumio/miniconda` docker images found [here](https://hub.docker.com/r/continuumio/miniconda)):

  1) Start up miniconda container: 
	```
	docker run -it --rm continuumio/miniconda3
	```

  2) Inside the container, setup dependencies and channels:
	```
	apt update -y && \
	apt install -y build-essential gcc && \
	conda config --add channels conda-forge && \
	conda install -y pybind11 libsolv pip
	```

  3) Fetch mamba source:
	```
	git clone https://github.com/marshallmcdonnell/mamba.git
	cd mamba
	```

  4) Reproduce error:
	```
	git checkout master && \
	pip install -e . && \
	mamba install numpy
	```

  5) Show fix works:
	```
	git checkout master && \
	pip install -e . && \
	mamba install numpy
	```

**NOTE:** I used both https://hub.docker.com/r/continuumio/miniconda2 and https://hub.docker.com/r/continuumio/miniconda3 images. Both work. The instructions are same for both.