### PR TITLE
Substitute url_w_credentials for url_w_subdir

### DIFF
--- a/mamba/mamba_env.py
+++ b/mamba/mamba_env.py
@@ -43,7 +43,7 @@ def mamba_install(prefix, specs, args, env, *_, **kwargs):
 
     for x in index:
         # add priority here
-        priority = len(_channel_priority_map) - _channel_priority_map[x.url_w_subdir][1]
+        priority = len(_channel_priority_map) - _channel_priority_map[x.url_w_credentials][1]
         subpriority = 0 if x.channel.platform == 'noarch' else 1
         if os.path.exists(x.cache_path_solv):
             cache_file = x.cache_path_solv


### PR DESCRIPTION
What?
=====

Uses `url_w_credentials` in place of `url_w_subdir` when looking up
channels in the priority map.

Why?
====

We use a private channel repository in conda and we are getting an
error here.
Stepping through the source code in a debugger it looks like the dict
key values of `_channel_priority_map` match the values of
`url_w_credentials` for cases where we are logged in (and do not need
 more than the channel name) and when we are logged out of anaconda
 (and thus require a url + token as our channel).