### PR TITLE
add experimental C++

### DIFF
--- a/experiments/CMakeLists.txt
+++ b/experiments/CMakeLists.txt
@@ -1,0 +1,30 @@
+cmake_minimum_required(VERSION 3.2)
+
+project(testxxx)
+
+set(CMAKE_CXX_FLAGS -std=c++17)
+
+set(CMAKE_BUILD_TYPE "Debug")
+
+find_package(PkgConfig REQUIRED)
+find_package(OpenSSL REQUIRED)
+# find_package(skyr-url REQUIRED)
+pkg_search_module(GLIB REQUIRED glib-2.0 HINTS )
+
+find_library(REPO_LIBRARIES 
+	NAMES repo)
+
+# set(CMAKE_SKIP_BUILD_RPATH FALSE)
+# set(CMAKE_BUILD_WITH_INSTALL_RPATH TRUE)
+# set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
+# set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+# set(CMAKE_MACOSX_RPATH OFF)
+
+add_executable(subi subdirdata.cpp)
+set_target_properties(subi 
+  PROPERTIES
+	MACOSX_RPATH ON)
+target_include_directories(subi PRIVATE ${GLIB_INCLUDE_DIRS})
+target_link_libraries(subi PUBLIC ${GLIB_LINK_LIBRARIES})
+
+target_link_libraries(subi PUBLIC ${REPO_LIBRARIES} ${OPENSSL_LIBRARIES} /home/wolfv/miniconda3/lib/libskyr-url.so)

--- a/experiments/constants.hpp
+++ b/experiments/constants.hpp
@@ -1,0 +1,5 @@
+#pragma once
+
+#include <string>
+
+const std::string PACKAGE_CACHE_MAGIC_FILE("urls.txt");

--- a/experiments/context.hpp
+++ b/experiments/context.hpp
@@ -8,7 +8,8 @@ class Context
 {
 public:
 
-	std::vector<std::string> pkgs_dirs = {"$CONDA_PREFIX/pkgs"};
+    // TODO $CONDA_PREFIX doesn't work.
+    std::vector<std::string> pkgs_dirs = {"$CONDA_PREFIX/pkgs"};
 
     Context(Context const&) = delete;
     Context& operator=(Context const&) = delete;

--- a/experiments/context.hpp
+++ b/experiments/context.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <vector>
+#include <string>
+
+// Context singleton class
+class Context
+{
+public:
+
+	std::vector<std::string> pkgs_dirs = {"$CONDA_PREFIX/pkgs"};
+
+    Context(Context const&) = delete;
+    Context& operator=(Context const&) = delete;
+
+    static std::shared_ptr<Context> instance()
+    {
+        static std::shared_ptr<Context> s{new Context};
+        return s;
+    }
+
+private:
+    Context() {}
+};

--- a/experiments/package_cache_data.hpp
+++ b/experiments/package_cache_data.hpp
@@ -6,105 +6,105 @@
 #include "path.hpp"
 
 enum Writable {
-	UNKNOWN,
-	WRITABLE,
-	NOT_WRITABLE,
-	DIR_DOES_NOT_EXIST
+    UNKNOWN,
+    WRITABLE,
+    NOT_WRITABLE,
+    DIR_DOES_NOT_EXIST
 };
 
 class PackageCacheData
 {
 public:
-	PackageCacheData(const std::string& pkgs_dir)
-		: m_pkgs_dir(pkgs_dir)
-	{
-	}
+    PackageCacheData(const std::string& pkgs_dir)
+        : m_pkgs_dir(pkgs_dir)
+    {
+    }
 
-	bool create_directory()
-	{
-		// from python: create_package_cache_directory
-		try
-		{
-			std::cout << "Attempt to create package cache directory '" << m_pkgs_dir << "'" << std::endl;
-			bool sudo_safe = path::starts_with_home(m_pkgs_dir);
-			path::touch(path::join(m_pkgs_dir, PACKAGE_CACHE_MAGIC_FILE), sudo_safe, /*mkdir*/true);
-			// TODO why magic string "urls" here? is it necessary?
-			path::touch(path::join(m_pkgs_dir, "urls"), sudo_safe);
-			return true;
-		}
-		catch(...)
-		{
-			// TODO better error handling
+    bool create_directory()
+    {
+        // from python: create_package_cache_directory
+        try
+        {
+            std::cout << "Attempt to create package cache directory '" << m_pkgs_dir << "'" << std::endl;
+            bool sudo_safe = path::starts_with_home(m_pkgs_dir);
+            path::touch(path::join(m_pkgs_dir, PACKAGE_CACHE_MAGIC_FILE), sudo_safe, /*mkdir*/true);
+            // TODO why magic string "urls" here? is it necessary?
+            path::touch(path::join(m_pkgs_dir, "urls"), sudo_safe);
+            return true;
+        }
+        catch(...)
+        {
+            // TODO better error handling
             std::cout << "cannot create package cache directory " << m_pkgs_dir << std::endl;
-			return false;
-		}
-	}
+            return false;
+        }
+    }
 
-	void set_writable(Writable writable)
-	{
-		m_writable = writable;
-	}
+    void set_writable(Writable writable)
+    {
+        m_writable = writable;
+    }
 
-	Writable is_writable()
-	{
-		if (m_writable == UNKNOWN)
-		{
-			check_writable();
-		}
-		return m_writable;
-	}
+    Writable is_writable()
+    {
+        if (m_writable == UNKNOWN)
+        {
+            check_writable();
+        }
+        return m_writable;
+    }
 
-	static PackageCacheData first_writable(const std::vector<std::string>* pkgs_dirs = nullptr) {
-		const std::vector<std::string>* dirs = pkgs_dirs ? pkgs_dirs : &Context::instance()->pkgs_dirs;
-		for (const auto& dir : (*dirs))
-		{
-			std::cout << "Checking dir " << dir << std::endl;
-			PackageCacheData pkgs_cache(dir);
-			auto is_wri = pkgs_cache.is_writable();
+    static PackageCacheData first_writable(const std::vector<std::string>* pkgs_dirs = nullptr) {
+        const std::vector<std::string>* dirs = pkgs_dirs ? pkgs_dirs : &Context::instance()->pkgs_dirs;
+        for (const auto& dir : (*dirs))
+        {
+            std::cout << "Checking dir " << dir << std::endl;
+            PackageCacheData pkgs_cache(dir);
+            auto is_wri = pkgs_cache.is_writable();
 
-			if (is_wri == WRITABLE)
-			{
-				return pkgs_cache;
-			}
-			else if (is_wri == DIR_DOES_NOT_EXIST)
-			{
-				bool created = pkgs_cache.create_directory();
-				if (created)
-				{
-					pkgs_cache.set_writable(WRITABLE);
-					return pkgs_cache;
-				}
-			}
-		}
-		// TODO better error class?!
-		throw std::runtime_error("Did not find a writable package cache directory!");
-	}
+            if (is_wri == WRITABLE)
+            {
+                return pkgs_cache;
+            }
+            else if (is_wri == DIR_DOES_NOT_EXIST)
+            {
+                bool created = pkgs_cache.create_directory();
+                if (created)
+                {
+                    pkgs_cache.set_writable(WRITABLE);
+                    return pkgs_cache;
+                }
+            }
+        }
+        // TODO better error class?!
+        throw std::runtime_error("Did not find a writable package cache directory!");
+    }
 
 private:
 
-	void check_writable()
-	{
-		fs::path magic_file = fs::path(m_pkgs_dir) / fs::path(PACKAGE_CACHE_MAGIC_FILE);
-		if (fs::is_regular_file(magic_file))
-		{
-			std::cout << "File exists, checking if writable" << std::endl;;
-			if (path::file_path_is_writable(magic_file))
-			{
-				m_writable = WRITABLE;
-				std::cout << "Yes, writable" << std::endl;;
-			}
-			else
-			{
-				m_writable = NOT_WRITABLE;
-				std::cout << "Not writable" << std::endl;;
-			}
-		}
-		else
-		{
-			m_writable = DIR_DOES_NOT_EXIST;
-		}
-	}
+    void check_writable()
+    {
+        fs::path magic_file = fs::path(m_pkgs_dir) / fs::path(PACKAGE_CACHE_MAGIC_FILE);
+        if (fs::is_regular_file(magic_file))
+        {
+            std::cout << "File exists, checking if writable" << std::endl;;
+            if (path::file_path_is_writable(magic_file))
+            {
+                m_writable = WRITABLE;
+                std::cout << "Yes, writable" << std::endl;;
+            }
+            else
+            {
+                m_writable = NOT_WRITABLE;
+                std::cout << "Not writable" << std::endl;;
+            }
+        }
+        else
+        {
+            m_writable = DIR_DOES_NOT_EXIST;
+        }
+    }
 
-	Writable m_writable = UNKNOWN;
-	std::string m_pkgs_dir;
+    Writable m_writable = UNKNOWN;
+    std::string m_pkgs_dir;
 };

--- a/experiments/package_cache_data.hpp
+++ b/experiments/package_cache_data.hpp
@@ -1,0 +1,110 @@
+#include <vector>
+#include <string>
+
+#include "constants.hpp"
+#include "context.hpp"
+#include "path.hpp"
+
+enum Writable {
+	UNKNOWN,
+	WRITABLE,
+	NOT_WRITABLE,
+	DIR_DOES_NOT_EXIST
+};
+
+class PackageCacheData
+{
+public:
+	PackageCacheData(const std::string& pkgs_dir)
+		: m_pkgs_dir(pkgs_dir)
+	{
+	}
+
+	bool create_directory()
+	{
+		// from python: create_package_cache_directory
+		try
+		{
+			std::cout << "Attempt to create package cache directory '" << m_pkgs_dir << "'" << std::endl;
+			bool sudo_safe = path::starts_with_home(m_pkgs_dir);
+			path::touch(path::join(m_pkgs_dir, PACKAGE_CACHE_MAGIC_FILE), sudo_safe, /*mkdir*/true);
+			// TODO why magic string "urls" here? is it necessary?
+			path::touch(path::join(m_pkgs_dir, "urls"), sudo_safe);
+			return true;
+		}
+		catch(...)
+		{
+			// TODO better error handling
+            std::cout << "cannot create package cache directory " << m_pkgs_dir << std::endl;
+			return false;
+		}
+	}
+
+	void set_writable(Writable writable)
+	{
+		m_writable = writable;
+	}
+
+	Writable is_writable()
+	{
+		if (m_writable == UNKNOWN)
+		{
+			check_writable();
+		}
+		return m_writable;
+	}
+
+	static PackageCacheData first_writable(const std::vector<std::string>* pkgs_dirs = nullptr) {
+		const std::vector<std::string>* dirs = pkgs_dirs ? pkgs_dirs : &Context::instance()->pkgs_dirs;
+		for (const auto& dir : (*dirs))
+		{
+			std::cout << "Checking dir " << dir << std::endl;
+			PackageCacheData pkgs_cache(dir);
+			auto is_wri = pkgs_cache.is_writable();
+
+			if (is_wri == WRITABLE)
+			{
+				return pkgs_cache;
+			}
+			else if (is_wri == DIR_DOES_NOT_EXIST)
+			{
+				bool created = pkgs_cache.create_directory();
+				if (created)
+				{
+					pkgs_cache.set_writable(WRITABLE);
+					return pkgs_cache;
+				}
+			}
+		}
+		// TODO better error class?!
+		throw std::runtime_error("Did not find a writable package cache directory!");
+	}
+
+private:
+
+	void check_writable()
+	{
+		fs::path magic_file = fs::path(m_pkgs_dir) / fs::path(PACKAGE_CACHE_MAGIC_FILE);
+		if (fs::is_regular_file(magic_file))
+		{
+			std::cout << "File exists, checking if writable" << std::endl;;
+			if (path::file_path_is_writable(magic_file))
+			{
+				m_writable = WRITABLE;
+				std::cout << "Yes, writable" << std::endl;;
+			}
+			else
+			{
+				m_writable = NOT_WRITABLE;
+				std::cout << "Not writable" << std::endl;;
+			}
+		}
+		else
+		{
+			m_writable = DIR_DOES_NOT_EXIST;
+		}
+	}
+
+	Writable m_writable = UNKNOWN;
+	std::string m_pkgs_dir;
+};

--- a/experiments/path.hpp
+++ b/experiments/path.hpp
@@ -1,0 +1,320 @@
+#pragma once
+
+#include <string>
+#include <fstream>
+#include <filesystem>
+#include <chrono>
+#include <regex>
+
+// #include <pystring14/pystring.hpp>
+
+// MD5 hash
+#include <openssl/md5.h>
+
+namespace fs = std::filesystem;
+
+
+static bool ends_with(const std::string& str, const std::string& suffix)
+{
+    return str.size() >= suffix.size() && 0 == str.compare(str.size() - suffix.size(), suffix.size(), suffix);
+}
+
+static bool starts_with(const std::string& str, const std::string& prefix)
+{
+    return str.size() >= prefix.size() && 0 == str.compare(0, prefix.size(), prefix);
+}
+
+namespace path
+{
+    constexpr char pathsep() {
+        #if _WIN32
+            return '\\';
+        #else
+            return '/';
+        #endif
+    }
+
+    std::string join(const std::string& a, const std::string& b)
+    {
+        std::string res = a;
+        // TODO do something more clever here! (adding slashes, and checking for double slashes)
+        if (res.size() && res[res.size() - 1] != pathsep()) res += pathsep();
+        res += b;
+        return res;
+    }
+
+    std::string cache_fn_url(const std::string& url)
+    {
+        // if (repodata_fn != REPODATA_FN)
+        // {
+        //     url += repodata_fn;
+        // }
+
+        unsigned char result[MD5_DIGEST_LENGTH];
+        MD5((const unsigned char*) url.c_str(), url.size(), result);
+        
+        std::ostringstream sout;
+        sout << std::hex << std::setfill('0');
+
+        for(long long c: result)
+        {
+            sout << std::setw(2) << (long long) c;
+        }
+
+        return sout.str() + ".json";
+    }
+
+    bool uncompress_bz2(const std::string& path)
+    {
+        // remove `.bz2` from end of filename
+        std::string final_name(path.begin(), path.end() - 4);
+        std::string cmd = std::string("bzip2 --stdout -d ") + path + " > " + final_name; 
+        std::cout << "Executing: " << cmd << std::endl;
+        std::system(cmd.c_str());
+        return true;
+        // cmd = std::string("rm ") + path;
+        // std::system(cmd.c_str());
+    }
+
+    // def touch(path, mkdir=False, sudo_safe=False):
+    //     # sudo_safe: use any time `path` is within the user's home directory
+    //     # returns:
+    //     #   True if the file did not exist but was created
+    //     #   False if the file already existed
+    //     # raises: NotWritableError, which is also an OSError having attached errno
+    //     try:
+    //         path = expand(path)
+    //         log.trace("touching path %s", path)
+    //         if lexists(path):
+    //             os.utime(path, None)
+    //             return True
+    //         else:
+    //             dirpath = dirname(path)
+    //             if not isdir(dirpath) and mkdir:
+    //                 if sudo_safe:
+    //                     mkdir_p_sudo_safe(dirpath)
+    //                 else:
+    //                     mkdir_p(dirpath)
+    //             else:
+    //                 assert isdir(dirname(path))
+    //             with open(path, 'a'):
+    //                 pass
+    //             # This chown call causes a false positive PermissionError to be
+    //             # raised (similar to #7109) when called in an environment which
+    //             # comes from sudo -u.
+    //             #
+    //             # if sudo_safe and not on_win and os.environ.get('SUDO_UID') is not None:
+    //             #     uid = int(os.environ['SUDO_UID'])
+    //             #     gid = int(os.environ.get('SUDO_GID', -1))
+    //             #     log.trace("chowning %s:%s %s", uid, gid, path)
+    //             #     os.chown(path, uid, gid)
+    //             return False
+    //     except (IOError, OSError) as e:
+    //         raise NotWritableError(path, e.errno, caused_by=e)
+
+    // expand user
+    // note this should also expand to absolute path etc.
+    fs::path expand(const fs::path& path)
+    {
+        std::string p = path;
+        if (not p.empty() and p[0] == '~')
+        {
+            const char* home = getenv("HOME");
+
+            if (home || (home = getenv("USERPROFILE")))
+            {
+                p.replace(0, 1, home);
+            }
+            else
+            {
+                const char* hdrive = getenv("HOMEDRIVE");
+                const char* hpath = getenv("HOMEPATH");
+                if (!hdrive || !hpath) throw std::runtime_error("Could not find $HOME, %USERPROFILE%, %HOMEDRIVE% or %HOMEPATH%.");
+                p.replace(0, 1, std::string(hdrive) + hpath);
+            }
+        }
+        return p;
+    }
+
+    bool starts_with_home(const fs::path& path)
+    {
+        std::string ps = path;
+        if (ps[0] == '~') return true;
+        auto home = expand("~");
+        if (starts_with(path, home))
+        {
+            return true;
+        }
+        return false;
+    }
+
+    bool lexists(const fs::path& path)
+    {
+        return fs::status_known(fs::symlink_status(path));
+    }
+
+    void mkdir_p(const fs::path& path)
+    {
+        if (fs::is_directory(path)) return;
+        std::cout << "making directory " << path << std::endl;
+        fs::create_directories(path);
+    }
+
+    // TODO more error handling
+    void mkdir_p_sudo_safe(const fs::path& path)
+    {
+        if (fs::is_directory(path)) return;
+
+        fs::path base_dir = path.parent_path();
+        if (!fs::is_directory(base_dir))
+        {
+            mkdir_p_sudo_safe(base_dir);
+        }
+        std::cout << "making directory " << path << std::endl;
+        fs::create_directory(path);
+
+        #ifndef _WIN32
+        // set permissions to 0o2775
+        fs::permissions(path, fs::perms::set_gid |
+                              fs::perms::owner_all | 
+                              fs::perms::group_all |
+                              fs::perms::others_read | fs::perms::others_exec);
+        #endif
+    }
+
+    template <class T>
+    auto now(std::chrono::time_point<T>)
+    {
+        return T::now();
+    }
+
+    bool touch(fs::path path, bool mkdir=false, bool sudo_safe=false)
+    {
+        // TODO error handling!
+        path = expand(path);
+        std::cout << "touching " << path << std::endl;
+        if (lexists(path))
+        {
+            fs::last_write_time(path, now(fs::file_time_type{}));
+            return true;
+        }
+        else
+        {
+            auto dirpath = path.parent_path();
+            if (!fs::is_directory(dirpath) && mkdir)
+            {
+                if (sudo_safe)
+                {
+                    mkdir_p_sudo_safe(dirpath);
+                }
+                else
+                {
+                    mkdir_p(dirpath);
+                }
+            }
+            // directory exists, now create empty file
+            std::ofstream(path);
+            return false;
+        }
+    }
+
+    bool file_path_is_writable(const fs::path& path)
+    {
+        // path = expand(path)
+        std::cout << "Checking that path is writable: " << path << std::endl;
+        if (fs::is_directory(path.parent_path()))
+        {
+            bool path_existed = lexists(path);
+            std::ofstream test;
+            test.open(path);
+            bool is_writable = test.is_open();
+            if (!path_existed)
+            {
+                test.close();
+                fs::remove(path);
+            }
+            return is_writable;
+        }
+        else
+        {
+            throw std::runtime_error("Cannot check file path at `/` for accessibility.");
+        }
+    }
+
+    // PATH_MATCH_REGEX = (
+    //     r"\./"              # ./
+    //     r"|\.\."            # ..
+    //     r"|~"               # ~
+    //     r"|/"               # /
+    //     r"|[a-zA-Z]:[/\\]"  # drive letter, colon, forward or backslash
+    //     r"|\\\\"            # windows UNC path
+    //     r"|//"              # windows UNC path
+    // )
+
+    const std::regex path_regex("\\./|\\.\\.|~|/|[a-zA-Z]:[/\\\\]|\\\\\\\\|//");
+
+    bool is_path(const std::string& value)
+    {
+        if (value.find("://") != std::string::npos) 
+        {
+            return false;
+        }
+        return std::regex_search(value, path_regex);
+    }
+
+// def path_to_url(path):
+//     if not path:
+//         raise ValueError('Not allowed: %r' % path)
+//     if path.startswith(file_scheme):
+//         try:
+//             path.decode('ascii')
+//         except UnicodeDecodeError:
+//             raise ValueError('Non-ascii not allowed for things claiming to be URLs: %r' % path)
+//         return path
+//     path = abspath(expanduser(path)).replace('\\', '/')
+//     # We do not use urljoin here because we want to take our own
+//     # *very* explicit control of how paths get encoded into URLs.
+//     #   We should not follow any RFCs on how to encode and decode
+//     # them, we just need to make sure we can represent them in a
+//     # way that will not cause problems for whatever amount of
+//     # urllib processing we *do* need to do on them (which should
+//     # be none anyway, but I doubt that is the case). I have gone
+//     # for ASCII and % encoding of everything not alphanumeric or
+//     # not in `!'()*-._/:`. This should be pretty save.
+//     #
+//     # To avoid risking breaking the internet, this code only runs
+//     # for `file://` URLs.
+//     #
+//     percent_encode_chars = "!'()*-._/\\:"
+//     percent_encode = lambda s: "".join(["%%%02X" % ord(c), c]
+//                                        [c < "{" and c.isalnum() or c in percent_encode_chars]
+//                                        for c in s)
+//     if any(ord(char) >= 128 for char in path):
+//         path = percent_encode(path.decode('unicode-escape')
+//                               if hasattr(path, 'decode')
+//                               else bytes(path, "utf-8").decode('unicode-escape'))
+
+//     # https://blogs.msdn.microsoft.com/ie/2006/12/06/file-uris-in-windows/
+//     if len(path) > 1 and path[1] == ':':
+//         path = file_scheme + '/' + path
+//     else:
+//         path = file_scheme + path
+//     return path
+
+    bool is_package_file(const std::string& path)
+    {
+        // TODO use constants here!
+        return ends_with(path, ".conda") || ends_with(path, ".tar.bz2");
+    }
+
+    std::string win_path_backout(const std::string& path)
+    {
+        // replace all backslashes except those escaping spaces
+        // if we pass a file url, something like file://\\unc\path\on\win, make sure
+        //   we clean that up too
+        std::regex rex("(\\\\(?! ))");
+        auto res = std::regex_replace(path, rex, "/");
+        res = std::regex_replace(res, std::regex(":////"), "://");
+        return res;
+    }
+}

--- a/experiments/path.hpp
+++ b/experiments/path.hpp
@@ -13,7 +13,6 @@
 
 namespace fs = std::filesystem;
 
-
 static bool ends_with(const std::string& str, const std::string& suffix)
 {
     return str.size() >= suffix.size() && 0 == str.compare(str.size() - suffix.size(), suffix.size(), suffix);
@@ -45,10 +44,7 @@ namespace path
 
     std::string cache_fn_url(const std::string& url)
     {
-        // if (repodata_fn != REPODATA_FN)
-        // {
-        //     url += repodata_fn;
-        // }
+        // if (repodata_fn != REPODATA_FN) url += repodata_fn;
 
         unsigned char result[MD5_DIGEST_LENGTH];
         MD5((const unsigned char*) url.c_str(), url.size(), result);
@@ -75,42 +71,6 @@ namespace path
         // cmd = std::string("rm ") + path;
         // std::system(cmd.c_str());
     }
-
-    // def touch(path, mkdir=False, sudo_safe=False):
-    //     # sudo_safe: use any time `path` is within the user's home directory
-    //     # returns:
-    //     #   True if the file did not exist but was created
-    //     #   False if the file already existed
-    //     # raises: NotWritableError, which is also an OSError having attached errno
-    //     try:
-    //         path = expand(path)
-    //         log.trace("touching path %s", path)
-    //         if lexists(path):
-    //             os.utime(path, None)
-    //             return True
-    //         else:
-    //             dirpath = dirname(path)
-    //             if not isdir(dirpath) and mkdir:
-    //                 if sudo_safe:
-    //                     mkdir_p_sudo_safe(dirpath)
-    //                 else:
-    //                     mkdir_p(dirpath)
-    //             else:
-    //                 assert isdir(dirname(path))
-    //             with open(path, 'a'):
-    //                 pass
-    //             # This chown call causes a false positive PermissionError to be
-    //             # raised (similar to #7109) when called in an environment which
-    //             # comes from sudo -u.
-    //             #
-    //             # if sudo_safe and not on_win and os.environ.get('SUDO_UID') is not None:
-    //             #     uid = int(os.environ['SUDO_UID'])
-    //             #     gid = int(os.environ.get('SUDO_GID', -1))
-    //             #     log.trace("chowning %s:%s %s", uid, gid, path)
-    //             #     os.chown(path, uid, gid)
-    //             return False
-    //     except (IOError, OSError) as e:
-    //         raise NotWritableError(path, e.errno, caused_by=e)
 
     // expand user
     // note this should also expand to absolute path etc.

--- a/experiments/subdirdata.cpp
+++ b/experiments/subdirdata.cpp
@@ -1,0 +1,386 @@
+#include <string>
+#include <memory>
+#include <iostream>
+#include <filesystem>
+
+#include <skyr/url.hpp>
+
+#include "path.hpp"
+#include "package_cache_data.hpp"
+
+extern "C" {
+    #include <glib.h>
+    #include <stdlib.h>
+    #include <stdio.h>
+    #include <librepo/librepo.h>
+}
+
+const std::string REPODATA_FN = "repodata.json";
+
+static void
+log_handler_cb(const gchar *log_domain G_GNUC_UNUSED,
+               GLogLevelFlags log_level G_GNUC_UNUSED,
+               const gchar *message,
+               gpointer user_data G_GNUC_UNUSED)
+{
+    g_print ("%s\n", message);
+}
+
+struct ProgressData {
+    std::string name;
+    bool compressed;
+    std::string filename;
+};
+
+static int
+progress_callback(void *data,
+                  double total_to_download,
+                  double now_downloaded)
+{
+    auto& name = ((ProgressData*) data)->name;
+    std::cout << "\r" << name << ": " << total_to_download << " / " << now_downloaded;
+    fflush(stdout);
+    return 0;
+}
+
+static int
+end_callback(void* data, LrTransferStatus status, const char* msg)
+{
+    std::cout << "\n";
+    if (msg)
+    {
+        std::cout << msg << std::endl;
+    }
+
+    auto* pdata = (ProgressData*) data;
+    if (pdata->compressed)
+    {
+        // Not in a thread, also ugly code since calling out to the shell...
+        path::uncompress_bz2(pdata->filename);
+    }
+    return 0;
+}
+
+class Result 
+{
+public:
+    Result(LrResult* result)
+        : m_result(result)
+    {
+    }
+
+    ~Result()
+    {
+        lr_result_free(m_result);
+    }
+
+    LrResult* m_result;
+};
+
+class Handle
+{
+public:
+    Handle() {
+        m_handle = lr_handle_init();
+    }
+
+    ~Handle() {
+        lr_handle_free(m_handle);
+    }
+
+    LrHandle* get() {
+        return m_handle;
+    }
+
+    Result perform() {
+        LrResult* result = lr_result_init();
+        GError* tmp_err = NULL;
+        std::cout << "Downloading! " << std::endl;
+        lr_handle_perform(m_handle, result, &tmp_err);
+        // g_error_free(tmp_err);
+        char *destdir;
+        lr_handle_getinfo(m_handle, NULL, LRI_DESTDIR, &destdir);
+
+        if (result) {
+            printf("Download successful (Destination dir: %s)\n", destdir);
+        } else {
+            fprintf(stderr, "Error encountered: %s\n", tmp_err->message);
+            g_error_free(tmp_err);
+            // rc = EXIT_FAILURE;
+        }
+
+        return result;
+    }
+
+    LrHandle* m_handle;
+};
+
+class DownloadTarget {
+public:
+
+    DownloadTarget(
+        Handle& handle,
+        const std::string& name,
+        const std::string& url,
+        const std::string& filename) :
+            m_progress_data{name, true, filename}
+    {
+        std::string name1 = std::tmpnam(nullptr);
+        std::cout << "Target for " << name << std::endl;
+        m_target = lr_downloadtarget_new(
+            handle.get(),     // ptr to handle
+            url.c_str(),      // url (absolute, or relative)
+            nullptr,          // base url
+            -1,               // file descriptor (opened)
+            filename.c_str(), // filename
+            nullptr,          // possible checksums
+            0,                // expected size
+            true,             // resume
+            progress_callback,// progress cb
+            &m_progress_data, // cb data
+            end_callback,     // end cb
+            nullptr,          // mirror failure cb
+            nullptr,          // user data
+            0,                // byte range start (download only range)
+            0,                // byte range end
+            nullptr,          // range string (overrides start / end, usage unclear)
+            false,            // no_cache (tell proxy server that we want fresh data)
+            false             // is zchunk
+        );
+    }
+
+    bool download()
+    {
+        GError* tmp_err = NULL;
+        bool result = lr_download_target(m_target, &tmp_err);
+
+        if (result) {
+            printf("Download successful\n");
+        } else {
+            fprintf(stderr, "Error encountered: %s\n", tmp_err->message);
+            g_error_free(tmp_err);
+            // rc = EXIT_FAILURE;
+        }
+        return result;
+    }
+
+    LrDownloadTarget* get()
+    {
+        return m_target;
+    }
+
+    ~DownloadTarget() {
+        lr_downloadtarget_free(m_target);
+    }
+
+    ProgressData m_progress_data;
+    LrDownloadTarget* m_target;
+};
+
+class DownloadTargetList
+{
+public:
+
+    DownloadTargetList()
+    {
+    }
+
+    void append(DownloadTarget& target)
+    {
+        m_download_targets = g_slist_append(m_download_targets, target.get());
+    }
+
+    bool download(bool failfast=true)
+    {
+        GError* tmp_err = NULL;
+        bool result = lr_download(m_download_targets, failfast, &tmp_err);
+
+        if (result) {
+            printf("Download successful\n");
+        } else {
+            fprintf(stderr, "Error encountered: %s\n", tmp_err->message);
+            g_error_free(tmp_err);
+            // rc = EXIT_FAILURE;
+        }
+        return result;
+    }
+
+    GSList* m_download_targets = nullptr;
+};
+
+
+class Channel {
+public:
+
+    Channel(const std::string& name, const std::string& url, int priority) :
+        m_name(name),
+        m_url(url),
+        m_priority(priority)
+    {
+    }
+
+    const std::string& name() const
+    {
+        return m_name;
+    }
+
+    std::string url(bool with_credentials=false) {
+        if (!with_credentials)
+        {
+            return m_url;
+        }
+        else
+        {
+            throw std::runtime_error("Not implemented yet!");
+        }
+    }
+
+    static Channel from_name(const std::string& name)
+    {
+        throw std::runtime_error("Not implemented yet!");
+        // return Channel()
+    }
+
+    // def _get_channel_for_name_helper(name):
+    //     if name in context.custom_channels:
+    //         return context.custom_channels[name]
+    //     else:
+    //         test_name = name.rsplit('/', 1)[0]  # progressively strip off path segments
+    //         if test_name == name:
+    //             return None
+    //         return _get_channel_for_name_helper(test_name)
+
+    // _stripped, platform = split_platform(channel_name, context.known_subdirs)
+    // channel = _get_channel_for_name_helper(_stripped)
+
+    // if channel is not None:
+    //     # stripping off path threw information away from channel_name (i.e. any potential subname)
+    //     # channel.name *should still be* channel_name
+    //     channel = copy(channel)
+    //     channel.name = _stripped
+    //     if platform:
+    //         channel.platform = platform
+    //     return channel
+    // else:
+    //     ca = context.channel_alias
+    //     return Channel(scheme=ca.scheme, auth=ca.auth, location=ca.location, token=ca.token,
+    //                    name=_stripped, platform=platform)
+
+    static Channel from_url(const std::string& uri)
+    {
+        if (uri == "<unknown>" || uri == "None:///<unknown>" || uri == "None")
+            return Channel("UNKNOWN_CHANNEL", "", -1);
+        auto parsed_uri = skyr::url(uri);
+        std::cout << parsed_uri.protocol() << std::endl;
+        if (parsed_uri.protocol() == "file:")
+        {
+            auto fixed_uri = path::win_path_backout(uri);
+            return Channel::from_url(fixed_uri);
+        }
+        else if (path::is_path(uri))
+        {
+            throw std::runtime_error("Not implemented yet!");
+            // return Channel::from_url(path::path_to_url(uri));
+        }
+        else if (path::is_package_file(uri))
+        {
+            // return Channel::from_url(value);
+        }
+        // elif is_package_file(value):
+        //     if value.startswith('file:'):
+        //         value = win_path_backout(value)
+        //     return Channel.from_url(value)
+        // else:
+        //     # at this point assume we don't have a bare (non-scheme) url
+        //     #   e.g. this would be bad:  repo.anaconda.com/pkgs/free
+        //     _stripped, platform = split_platform(value, context.known_subdirs)
+        //     if _stripped in context.custom_multichannels:
+        //         return MultiChannel(_stripped, context.custom_multichannels[_stripped], platform)
+        //     else:
+        //         return Channel.from_channel_name(value)
+        return Channel("asdasd", "", -1);
+    }
+
+private:
+
+    std::string m_name;
+    std::string m_url;
+    int m_priority;
+};
+
+class Subdir {
+public:
+
+    Subdir(const std::shared_ptr<Channel>& channel, const std::string& platform,
+           int sub_priority, const std::string& repodata_fn) : 
+        m_channel(channel),
+        m_platform(platform),
+        m_repodata_fn(repodata_fn),
+        m_sub_priority(sub_priority)
+    {
+        if (m_use_compression)
+        {
+            m_repodata_fn += ".bz2";
+        }
+    }
+
+    std::string name() const
+    {
+        return m_channel->name() + "/" + m_platform;
+    }
+
+    std::string url()
+    {
+        return path::join(path::join(m_channel->url(), m_platform), m_repodata_fn);
+    }
+
+    std::string cache_path()
+    {
+        return path::cache_fn_url(url());
+    }
+
+    DownloadTarget target(Handle& handle)
+    {
+        std::string cp = cache_path();
+        if (m_use_compression)
+        {
+            cp += ".bz2";
+        }
+        DownloadTarget target(handle, name(), url(), cp);
+        return target;
+    }
+
+private:
+    std::shared_ptr<Channel> m_channel;
+    std::string m_platform, m_repodata_fn;
+    bool m_loaded = false;
+    bool m_cached = false;
+    bool m_use_compression = true;
+    int m_sub_priority;
+};
+
+int main() {
+
+    // std::vector<std::string> pkgs_dirs = {"/etc/miniconda/", "/home/wolfv/miniconda3/pkgs/"};
+    // auto pcd = PackageCacheData::first_writable(&pkgs_dirs);
+
+    auto chan = Channel::from_url("https://conda.anaconda.org/conda-forge/");
+
+    // Handle handle;
+
+    // auto chan = std::make_shared<Channel>("conda-forge", "https://conda.anaconda.org/conda-forge/", 0);
+    // auto s1 = std::make_shared<Subdir>(chan, "linux-64", 0, "repodata.json");
+    // auto s2 = std::make_shared<Subdir>(chan, "noarch", 0, "repodata.json");
+
+    // std::cout << s1->url() << std::endl;
+    // auto t1 = s1->target(handle);
+    // std::cout << s2->url() << std::endl;
+    // auto t2 = s2->target(handle);
+    
+    // DownloadTargetList dls;
+    // dls.append(t1);
+    // dls.append(t2);
+    // dls.download();
+
+    return 0;
+}


### PR DESCRIPTION
This contains a branch where I attempt to port everything necessary for `FastSubdirData.py` to C++ so we can get rid of some of the Python.

This will need further love, but it shows how we can use librepo to download metadata for us and how we can structure the C++ to resemble conda. 

We should expand on this, but for the moment we might take a direction where we still use the conda "frontend" to extract the data and correct all the paths, and then copy the necessary data into pybind11-exposed classes.

E.g. we would have a `mamba.Channel` class that is backed by C++ and contains fields like `name`, `url`, `repodata_fn` (which is tedious to get from the raw arguments right now).
This class + the `Subdir` class would then take care of downloading the metadata to the cache.