### PR TITLE
Repoquery

### DIFF
--- a/include/py_interface.cpp
+++ b/include/py_interface.cpp
@@ -5,6 +5,7 @@
 #include "pool.hpp"
 #include "transaction.hpp"
 #include "repo.hpp"
+#include "query.hpp"
 
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
@@ -44,6 +45,12 @@ PYBIND11_MODULE(mamba_api, m) {
         .def("is_solved", &MSolver::is_solved)
         .def("problems_to_str", &MSolver::problems_to_str)
         .def("solve", &MSolver::solve)
+    ;
+
+    py::class_<Query>(m, "Query")
+        .def(py::init<MPool&>())
+        .def("find", &Query::find)
+        .def("whatrequires", &Query::whatrequires)
     ;
 
     m.attr("SOLVER_SOLVABLE") = SOLVER_SOLVABLE;

--- a/include/query.hpp
+++ b/include/query.hpp
@@ -1,0 +1,86 @@
+#include "pool.hpp"
+
+extern "C"
+{
+    #include "solv/solver.h"
+    #include "solv/selection.h"
+}
+
+
+namespace mamba
+{
+    class Query
+    {
+    public:
+
+        Query(MPool& pool)
+            : m_pool(pool)
+        {
+            m_pool.get().create_whatprovides();
+        }
+
+        std::string find(const std::string& query)
+        {
+            Queue job, solvables;
+            queue_init(&job);
+            queue_init(&solvables);
+
+            Id id = pool_conda_matchspec(m_pool.get(), query.c_str());
+            if (id)
+            {
+                queue_push2(&job, SOLVER_SOLVABLE_PROVIDES, id);
+            }
+            else
+            {
+                throw std::runtime_error("Could not generate query for " + query);
+            }
+
+            selection_solvables(m_pool.get(), &job, &solvables);
+
+            for (int i = 0; i < solvables.count; i++)
+            {
+                Id sid = solvables.elements[i];
+                Solvable* s = pool_id2solvable(m_pool.get(), sid);
+                printf("%s, %s, %s\n", pool_id2str(m_pool.get(), s->name), pool_id2str(m_pool.get(), s->evr), solvable_lookup_str(s, SOLVABLE_BUILDFLAVOR)); //, pool_id2str(pool, s->repo->name));
+            }
+
+            queue_free(&job);
+            queue_free(&solvables);
+
+            return "worked.";
+        }
+
+        std::string whatrequires(const std::string& query)
+        {
+            Queue job, solvables;
+            queue_init(&job);
+            queue_init(&solvables);
+
+            Id id = pool_conda_matchspec(m_pool.get(), query.c_str());
+            if (id)
+            {
+                queue_push2(&job, SOLVER_SOLVABLE_PROVIDES, id);
+            }
+            else
+            {
+                throw std::runtime_error("Could not generate query for " + query);
+            }
+
+            pool_whatmatchesdep(m_pool.get(), SOLVABLE_REQUIRES, id, &solvables, -1);
+
+            for (int i = 0; i < solvables.count; i++)
+            {
+                Id sid = solvables.elements[i];
+                Solvable* s = pool_id2solvable(m_pool.get(), sid);
+                printf("%s, %s, %s\n", pool_id2str(m_pool.get(), s->name), pool_id2str(m_pool.get(), s->evr), solvable_lookup_str(s, SOLVABLE_BUILDFLAVOR)); //, pool_id2str(pool, s->repo->name));
+            }
+
+            queue_free(&job);
+            queue_free(&solvables);
+
+            return "done.";
+        }
+
+        std::reference_wrapper<MPool> m_pool;
+    };
+}

--- a/include/transaction.hpp
+++ b/include/transaction.hpp
@@ -14,6 +14,7 @@ namespace mamba
             return;
         j[key] = val;
     }
+
     std::string solvable_to_json(Solvable* s)
     {
         nlohmann::json j;

--- a/include/util.hpp
+++ b/include/util.hpp
@@ -1,4 +1,7 @@
+#pragma once
+
 #include <stdexcept>
+#include <string_view>
 
 class mamba_error
     : public std::runtime_error
@@ -6,3 +9,13 @@ class mamba_error
 public:
     using std::runtime_error::runtime_error;
 };
+
+static bool ends_with(const std::string_view& str, const std::string_view& suffix)
+{
+    return str.size() >= suffix.size() && 0 == str.compare(str.size() - suffix.size(), suffix.size(), suffix);
+}
+
+static bool starts_with(const std::string_view& str, const std::string_view& prefix)
+{
+    return str.size() >= prefix.size() && 0 == str.compare(0, prefix.size(), prefix);
+}

--- a/mamba/mamba.py
+++ b/mamba/mamba.py
@@ -563,11 +563,12 @@ def repoquery(args, parser):
             repos.append(repo)
 
     print("\nExecuting the query %s\n" % args.query)
+
     query = api.Query(pool)
     if args.whatrequires:
         print(query.whatrequires(args.query))
     else:
-        query.find(args.query)
+        print(query.find(args.query))
 
 
 def do_call(args, parser):

--- a/mamba/mamba.py
+++ b/mamba/mamba.py
@@ -503,9 +503,76 @@ def update(args, parser):
     # need to implement some modifications on the update function
     install(args, parser, 'update')
 
+def repoquery(args, parser):
+    prepend = not args.override_channels
+    prefix = context.target_prefix
+
+    index_args = {
+        'use_cache': args.use_index_cache,
+        'channel_urls': context.channels,
+        'unknown': args.unknown,
+        'prepend': not args.override_channels,
+        'use_local': args.use_local
+    }
+
+    index = get_index(channel_urls=index_args['channel_urls'],
+                  prepend=index_args['prepend'], platform=None,
+                  use_local=index_args['use_local'], use_cache=index_args['use_cache'],
+                  unknown=index_args['unknown'], prefix=prefix)
+
+    channel_json = []
+    strict_priority = (context.channel_priority == ChannelPriority.STRICT)
+
+    if strict_priority:
+        # first, count unique channels
+        n_channels = len(set([x.channel.canonical_name for x in index]))
+        current_channel = index[0].channel.canonical_name
+        channel_prio = n_channels
+
+    for x in index:
+        # add priority here
+        x.channel_idx
+        if strict_priority:
+            if x.channel.canonical_name != current_channel:
+                channel_prio -= 1
+                current_channel = x.channel.canonical_name
+            priority = channel_prio
+        else:
+            priority = 0
+
+        subpriority = 0 if x.channel.platform == 'noarch' else 1
+        cache_file = x.get_loaded_file_path()
+
+        channel_json.append((str(x.channel), cache_file, priority, subpriority))
+
+    installed_json_f = get_installed_jsonfile(prefix)
+
+    pool = api.Pool()
+    pool.set_debuglevel(context.verbosity)
+    repos = []
+
+    # add installed
+    repo = api.Repo(pool, "installed", installed_json_f.name)
+    repo.set_installed()
+    repos.append(repo)
+
+    if not args.installed:
+        for channel_name, cache_file, priority, subpriority in channel_json:
+            repo = api.Repo(pool, channel_name, cache_file)
+            repo.set_priority(priority, subpriority)
+            repos.append(repo)
+
+    print("\nExecuting the query %s\n" % args.query)
+    query = api.Query(pool)
+    if args.whatrequires:
+        print(query.whatrequires(args.query))
+    else:
+        query.find(args.query)
+
 
 def do_call(args, parser):
     relative_mod, func_name = args.func.rsplit('.', 1)
+
     # func_name should always be 'execute'
     if relative_mod in ['.main_list', '.main_search', '.main_run', '.main_clean', '.main_info']:
         from importlib import import_module
@@ -519,17 +586,68 @@ def do_call(args, parser):
         exit_code = create(args, parser)
     elif relative_mod == '.main_update':
         exit_code = update(args, parser)
+    elif relative_mod == '.main_repoquery':
+        exit_code = repoquery(args, parser)
     else:
         print("Currently, only install, create, list, search, run, info and clean are supported through mamba.")
 
         return 0
     return exit_code
 
+def configure_parser_repoquery(sub_parsers):
+    help = "Query repositories using mamba. "
+    descr = (help)
+
+    example = ("""
+Examples:
+
+    conda repoquery xtensor>=0.18
+
+    """)
+
+    from argparse import SUPPRESS
+
+    p = sub_parsers.add_parser(
+        'repoquery',
+        description=descr,
+        help=help,
+        epilog=example,
+    )
+
+    p.add_argument(
+        'query',
+        action="store",
+        nargs='?',
+        help="Package query.",
+    )
+
+    p.add_argument(
+        "--whatrequires",
+        action="store_true",
+        help=SUPPRESS,
+    )
+
+    p.add_argument(
+        "--installed",
+        action="store_true",
+        help=SUPPRESS,
+    )
+
+    from conda.cli import conda_argparse
+    conda_argparse.add_parser_channels(p)
+    conda_argparse.add_parser_networking(p)
+    conda_argparse.add_parser_known(p)
+
+    p.set_defaults(func='.main_repoquery.execute')
+    return p
+
+
 def _wrapped_main(*args, **kwargs):
     if len(args) == 1:
         args = args + ('-h',)
 
     p = generate_parser()
+    configure_parser_repoquery(p._subparsers._group_actions[0])
     args = p.parse_args(args[1:])
 
     context.__init__(argparse_args=args)


### PR DESCRIPTION
First iteration for adding `repoquery` as a command.

These kind of queries already work:

```
(base) ~/Programs/mamba:master$ mamba repoquery --installed --whatrequires pyzmq
...

Executing the query pyzmq

jupyter_client, 6.0.0, py_0
notebook, 6.0.3, py37_0
done.
```

And:

`mamba repoquery xtensor` will show all available xtensor versions, `mamba repoquery xtensor>=0.15` all version >= 0.15 etc.

We will need 2 different output modes for this content:

- JSON (using nlohmann_json)
- Table-like output

cc @marimeireles 