### PR TITLE
Added url and patch_spec from #115

### DIFF
--- a/include/match_spec.hpp
+++ b/include/match_spec.hpp
@@ -1,0 +1,34 @@
+#ifndef MAMBA_MATCH_SPEC
+#define MAMBA_MATCH_SPEC
+
+#include <regex>
+#include <string>
+#include <unordered_map>
+
+namespace mamba
+{
+    class MatchSpec
+    {
+    public:
+
+        MatchSpec() = default;
+        MatchSpec(const std::string& i_spec);
+
+        void parse();
+
+        std::string spec;
+
+        std::string name;
+        std::string version;
+        std::string channel;
+        std::string ns;
+        std::string subdir;
+        std::string build;
+        std::string fn;
+        std::string url;
+
+        std::unordered_map<std::string, std::string> brackets;
+    };
+}
+
+#endif 

--- a/include/prefix_data.hpp
+++ b/include/prefix_data.hpp
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef MAMBA_PREFIX_DATA_HPP
+#define MAMBA_PREFIX_DATA_HPP
 
 #include <unordered_map>
 
@@ -40,5 +41,6 @@ namespace mamba
         std::unordered_map<std::string, PackageRecord> m_package_records;
         fs::path m_prefix_path;
     };
-
 }
+
+#endif

--- a/include/url.hpp
+++ b/include/url.hpp
@@ -1,0 +1,55 @@
+#ifndef MAMBA_URL_HPP
+#define MAMBA_URL_HPP
+
+#include <string>
+#include <stdexcept>
+
+extern "C"
+{
+    #include <curl/curl.h>
+}
+
+// typedef enum {
+//   CURLUE_OK,
+//   CURLUE_BAD_HANDLE,          /* 1 */
+//   CURLUE_BAD_PARTPOINTER,     /* 2 */
+//   CURLUE_MALFORMED_INPUT,     /* 3 */
+//   CURLUE_BAD_PORT_NUMBER,     /* 4 */
+//   CURLUE_UNSUPPORTED_SCHEME,  /* 5 */
+//   CURLUE_URLDECODE,           /* 6 */
+//   CURLUE_OUT_OF_MEMORY,       /* 7 */
+//   CURLUE_USER_NOT_ALLOWED,    /* 8 */
+//   CURLUE_UNKNOWN_PART,        /* 9 */
+//   CURLUE_NO_SCHEME,           /* 10 */
+//   CURLUE_NO_USER,             /* 11 */
+//   CURLUE_NO_PASSWORD,         /* 12 */
+//   CURLUE_NO_OPTIONS,          /* 13 */
+//   CURLUE_NO_HOST,             /* 14 */
+//   CURLUE_NO_PORT,             /* 15 */
+//   CURLUE_NO_QUERY,            /* 16 */
+//   CURLUE_NO_FRAGMENT          /* 17 */
+// } CURLUcode;
+
+namespace mamba
+{
+
+    bool is_url(const std::string& url);
+
+    class URLParser
+    {
+    public:
+    
+        URLParser(const std::string& url);
+        ~URLParser();
+
+        std::string scheme();
+
+    private:
+
+        std::string m_url;
+        CURLU* handle;
+    };
+
+}
+
+#endif

--- a/include/util.hpp
+++ b/include/util.hpp
@@ -17,8 +17,7 @@ namespace mamba
         using std::runtime_error::runtime_error;
     };
 
-    bool ends_with(const std::string_view& str, const std::string_view& suffix);
-    bool starts_with(const std::string_view& str, const std::string_view& prefix);
+    bool is_package_file(const std::string_view& fn);
     void to_human_readable_filesize(std::ostream& o, double bytes, std::size_t precision = 0);
     bool lexists(const fs::path& p);
 
@@ -60,6 +59,36 @@ namespace mamba
         fs::path m_path;
     };
 
+    /*************************
+     * utils for std::string *
+     *************************/
+
+    bool starts_with(const std::string_view& str, const std::string_view& prefix);
+    bool ends_with(const std::string_view& str, const std::string_view& suffix);
+
+    std::string_view strip(const std::string_view& input);
+    std::string_view lstrip(const std::string_view& input);
+    std::string_view rstrip(const std::string_view& input);
+
+    std::string_view strip(const std::string_view& input, const std::string_view& chars);
+    std::string_view lstrip(const std::string_view& input, const std::string_view& chars);
+    std::string_view rstrip(const std::string_view& input, const std::string_view& chars);
+
+    std::vector<std::string_view> split(const std::string_view& input,
+                                        char sep = ' ',
+                                        std::size_t max_split = SIZE_MAX);
+
+    std::vector<std::string_view> rsplit(const std::string_view& input,
+                                         char sep = ' ',
+                                         std::size_t max_split = SIZE_MAX);
+
+    /*std::vector<string_view> split(const std::string_view& input,
+                                   const std::string_view& sep,
+                                   std::size_t max_split = SIZE_MAX);
+
+    std::vector<string_view> split(const std::string_view& input,
+                                   const std::string_view& sep,
+                                   std::size_t max_split = SIZE_MAX);*/
 }
 
 #endif // MAMBA_UTIL_HPP

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,7 @@ ext_modules = [
         ['src/py_interface.cpp',
          'src/context.cpp',
          'src/fetch.cpp',
+         'src/match_spec.cpp',
          'src/output.cpp',
          'src/package_handling.cpp',
          'src/prefix_data.cpp',
@@ -72,6 +73,7 @@ ext_modules = [
          'src/solver.cpp',
          'src/subdirdata.cpp',
          'src/transaction.cpp',
+         'src/url.cpp',
          'src/util.cpp',
          'src/validate.cpp'],
         include_dirs=[

--- a/src/match_spec.cpp
+++ b/src/match_spec.cpp
@@ -1,0 +1,126 @@
+#include "match_spec.hpp"
+#include "output.hpp"
+#include "url.hpp"
+#include "util.hpp"
+
+namespace mamba
+{
+
+    MatchSpec::MatchSpec(const std::string& i_spec)
+        : spec(i_spec)
+    {
+        parse();
+    }
+
+    void MatchSpec::parse()
+    {
+        LOG_INFO << "Parsing MatchSpec " << spec;
+        std::string spec_str = spec;
+
+        std::size_t idx = spec_str.find('#');
+        if (idx != std::string::npos)
+        {
+            spec_str = spec_str.substr(0, idx);
+            spec_str = strip(spec_str);
+        }
+
+        if (is_package_file(spec_str))
+        {
+            if (!is_url(spec_str))
+            {
+                LOG_INFO << "need to expand path!";
+                // spec_str = unquote(path_to_url(expand(spec_str)))
+            }
+            LOG_INFO << "Got a package file: " << spec_str << std::endl;
+        }
+
+        // # Step 3. strip off brackets portion
+        // brackets = {}
+        // m3 = re.match(r'.*(?:(\[.*\]))', spec_str)
+        // if m3:
+        //     brackets_str = m3.groups()[0]
+        //     spec_str = spec_str.replace(brackets_str, '')
+        //     brackets_str = brackets_str[1:-1]
+        //     m3b = re.finditer(r'([a-zA-Z0-9_-]+?)=(["\']?)([^\'"]*?)(\2)(?:[, ]|$)', brackets_str)
+        //     for match in m3b:
+        //         key, _, value, _ = match.groups()
+        //         if not key or not value:
+        //             raise InvalidMatchSpec(original_spec_str, "key-value mismatch in brackets")
+        //         brackets[key] = value
+
+        std::regex brackets_re(".*(?:(\\[.*\\]))");
+        std::smatch match;
+        if (std::regex_match(spec_str, match, brackets_re))
+        {
+            auto brackets_str = match[1].str();
+            brackets_str = brackets_str.substr(1, brackets_str.size() - 2);
+            std::regex kv_re("([a-zA-Z0-9_-]+?)=([\"\']?)([^\'\"]*?)(?:[, ]|$)");
+
+            std::cmatch kv_match;
+            const char* text_iter = brackets_str.c_str();
+            while (std::regex_search(text_iter, (const char*) brackets_str.c_str() + brackets_str.size(), kv_match, kv_re))
+            {
+                auto key = kv_match[1].str();
+                auto value = kv_match[3].str();
+                if (key.size() == 0 || value.size() == 0) 
+                {
+                    throw std::runtime_error("key-value mismatch in brackets " + spec);
+                }
+                text_iter += kv_match.length(0);
+                brackets[key] = value;
+            }
+            spec_str.erase(match.position(1), match.length(1));
+        }
+
+        auto m5 = rsplit(spec_str, ':', 2);
+        auto m5_len = m5.size();
+        std::string channel_str;
+        if (m5_len == 3)
+        {
+            channel_str = m5[0];
+            ns = m5[1];
+            spec_str = m5[2];
+        }
+        else if (m5_len == 2)
+        {
+            ns = m5[0];
+            spec_str = m5[1];
+        }
+        else if (m5_len == 1)
+        {
+            spec_str = m5[0];
+        }
+        else
+        {
+            throw std::runtime_error("Parsing of channel / namespace / subdir failed.");
+        }
+        // TODO implement Channel, and parsing of the channel here!
+        channel = subdir = channel_str;
+        // channel, subdir = _parse_channel(channel_str)
+        // if 'channel' in brackets:
+        //     b_channel, b_subdir = _parse_channel(brackets.pop('channel'))
+        //     if b_channel:
+        //         channel = b_channel
+        //     if b_subdir:
+        //         subdir = b_subdir
+        // if 'subdir' in brackets:
+        //     subdir = brackets.pop('subdir')
+
+        // TODO This is #6 of the spec parsing -- we still need to port the others!
+        std::regex version_build_re("([^ =<>!~]+)?([><!=~ ].+)?");
+        std::smatch vb_match;
+        if (std::regex_match(spec_str, vb_match, version_build_re))
+        {
+            name = vb_match[1].str();
+            version = vb_match[2].str();
+            if (name.size() == 0)
+            {
+                throw std::runtime_error("Invalid spec, no package name found: " + spec_str);
+            }
+        }
+        else
+        {
+            throw std::runtime_error("Invalid spec, no package name found: " + spec_str);
+        }
+    }
+} 

--- a/src/url.cpp
+++ b/src/url.cpp
@@ -1,0 +1,55 @@
+#include "url.hpp"
+
+namespace mamba
+{
+    bool is_url(const std::string& url)
+    {
+	if (url.size() == 0) return false;
+	try
+        {
+	    URLParser p(url); 
+            return p.scheme().size() != 0;
+	}
+	catch(...)
+	{
+	    return false;
+	}
+    }
+
+    URLParser::URLParser(const std::string& url)
+        : m_url(url)
+    {
+        handle = curl_url(); /* get a handle to work with */ 
+        if (!handle)
+        {
+            throw std::runtime_error("Could not initiate URL parser.");
+        }
+        CURLUcode uc;
+        uc = curl_url_set(handle, CURLUPART_URL, url.c_str(), CURLU_NON_SUPPORT_SCHEME);
+        if (uc)
+        {
+            throw std::runtime_error("Could not set URL (code: " + std::to_string(uc) + ")");
+        }
+    }
+
+    URLParser::~URLParser()
+    {
+        curl_url_cleanup(handle);
+    }
+
+    std::string URLParser::scheme()
+    {
+        char* scheme;
+        auto rc = curl_url_get(handle, CURLUPART_SCHEME, &scheme, 0);
+        if (!rc)
+        {
+            std::string res(scheme);
+            curl_free(scheme);
+            return res;
+        }
+        else
+        {
+            throw std::runtime_error("Could not find SCHEME of url " + m_url);
+        }
+    }
+} 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -10,14 +10,9 @@
 
 namespace mamba
 {
-    bool ends_with(const std::string_view& str, const std::string_view& suffix)
+    bool is_package_file(const std::string_view& fn)
     {
-        return str.size() >= suffix.size() && 0 == str.compare(str.size() - suffix.size(), suffix.size(), suffix);
-    }
-
-    bool starts_with(const std::string_view& str, const std::string_view& prefix)
-    {
-        return str.size() >= prefix.size() && 0 == str.compare(0, prefix.size(), prefix);
+        return ends_with(fn, ".tar.bz2") || ends_with(fn, ".conda");
     }
 
     // TODO make sure this returns true even for broken symlinks
@@ -130,5 +125,103 @@ namespace mamba
         return m_path;
     }
 
+    /********************
+     * utils for string *
+     ********************/
+
+    bool ends_with(const std::string_view& str, const std::string_view& suffix)
+    {
+        return str.size() >= suffix.size() && 0 == str.compare(str.size() - suffix.size(), suffix.size(), suffix);
+    }
+
+    bool starts_with(const std::string_view& str, const std::string_view& prefix)
+    {
+        return str.size() >= prefix.size() && 0 == str.compare(0, prefix.size(), prefix);
+    }
+
+    namespace
+    {
+        const std::string WHITESPACES = " \r\n\t\f\v";
+    }
+
+    std::string_view strip(const std::string_view& input)
+    {
+        return strip(input, WHITESPACES);
+    }
+
+    std::string_view lstrip(const std::string_view& input)
+    {
+        return lstrip(input, WHITESPACES);
+    }
+
+    std::string_view rstrip(const std::string_view& input)
+    {
+        return rstrip(input, WHITESPACES);
+    }
+
+    std::string_view strip(const std::string_view& input, const std::string_view& chars)
+    {
+        size_t start = input.find_first_not_of(chars);
+        size_t stop = input.find_last_not_of(chars);
+        return start == std::string::npos ? "" : input.substr(start, stop);
+    }
+
+    std::string_view lstrip(const std::string_view& input, const std::string_view& chars)
+    {
+        size_t start = input.find_first_not_of(chars);
+        return start == std::string::npos ? "" : input.substr(start);
+    }
+
+    std::string_view rstrip(const std::string_view& input, const std::string_view& chars)
+    {
+        size_t end = input.find_last_not_of(chars);
+        return end == std::string::npos ? "" : input.substr(0, end + 1);
+    }
+
+
+    std::vector<std::string_view> split(const std::string_view& input,
+                                        char sep,
+                                        std::size_t max_split)
+    {
+        std::vector<std::string_view> res;
+        size_t nb_split = size_t(0);
+        auto start = input.find_first_not_of(sep);
+        auto end = input.find(sep, start + 1);
+        
+        while (nb_split < max_split && start != std::string_view::npos)
+        {
+            res.push_back(input.substr(start, end - start));
+            ++nb_split;
+            start = input.find_first_not_of(sep, end);
+            end = input.find(sep, start);
+        }
+        return res;
+    }
+
+    std::vector<std::string_view> rsplit(const std::string_view& input,
+                                         char sep,
+                                         std::size_t max_split)
+    {
+        std::vector<std::string_view> res;
+        auto nb_split = size_t(0);
+        auto end = input.find_last_not_of(sep);
+        auto start = input.find_last_of(sep, end);
+        ++end;
+
+        while(nb_split < 5 && start + 1 != 0)
+        {
+            res.push_back(input.substr(start + 1, end - start - 1));
+            ++nb_split;
+            end = input.find_last_not_of(sep, start);
+            start = end != std::string_view::npos ? input.find_last_of(sep, end) : end;
+            ++end;
+        }
+        if(nb_split < max_split && end != 0)
+        {
+            res.push_back(input.substr(start + 1, end - start - 1));
+        }
+        std::reverse(res.begin(), res.end());
+        return res;
+    }
 }
 


### PR DESCRIPTION
Files taken from #115. The biggest change is the refactoring of pystring. The methods were directly added to `utils.hpp`, we can also move them to a dedicated file (like `string_utils.hpp`).

The `split` and `rsplit` overloads that accept string separators have not been implemented yet. I will add them in a dedicated PR.