### PR TITLE
initial implementation of conda history parsing

### DIFF
--- a/include/history.hpp
+++ b/include/history.hpp
@@ -1,0 +1,62 @@
+#ifndef MAMBA_HISTORY
+#define MAMBA_HISTORY
+
+#include <vector>
+#include <regex>
+#include <set>
+
+#include "thirdparty/filesystem.hpp"
+
+#include "output.hpp"
+// #include "prefix_data.hpp"
+#include "match_spec.hpp"
+
+namespace fs = ghc::filesystem;
+
+namespace mamba
+{
+
+class History
+{
+public:
+
+    // History(const std::shared_ptr<PrefixData>& prefix)
+    //     : m_prefix_data(prefix)
+    // {
+    // }
+
+    History(const std::string& prefix);
+
+    struct ParseResult
+    {
+        std::string head_line;
+        std::set<std::string> diff;
+        std::vector<std::string> comments;
+    };
+
+    struct UserRequest
+    {
+        std::string cmd;
+        std::string conda_version;
+        std::string date;
+
+        std::vector<std::string> link_dists;
+        std::vector<std::string> unlink_dists;
+
+        std::vector<std::string> update;
+        std::vector<std::string> remove;
+        std::vector<std::string> neutered;
+    };
+
+    std::vector<ParseResult> parse();
+    bool parse_comment_line(const std::string& line, UserRequest& req);
+    std::vector<UserRequest> get_user_requests();
+    std::unordered_map<std::string, MatchSpec> get_requested_specs_map();
+
+    // std::shared_ptr<PrefixData> m_prefix_data;
+    std::string m_prefix_data;
+};
+
+}
+
+#endif

--- a/src/history.cpp
+++ b/src/history.cpp
@@ -1,0 +1,173 @@
+#include "history.hpp"
+
+namespace mamba
+{
+
+    History::History(const std::string& prefix)
+        : m_prefix_data(prefix)
+    {
+    }
+
+    std::vector<History::ParseResult> History::parse()
+    {
+        std::vector<ParseResult> res;
+        fs::path history_file_path = fs::path(m_prefix_data) / "conda-meta" / "history";
+        LOG_INFO << "parsing history: " << history_file_path;
+
+        if (!fs::exists(history_file_path))
+        {
+            // return empty
+            return res;
+        }
+
+        std::regex head_re("==>\\s*(.+?)\\s*<==");
+        std::ifstream in_file(history_file_path);
+        std::string line;
+        while (getline(in_file, line))
+        {
+            // line.strip()
+            if (line.size() == 0) continue;
+            std::smatch base_match;
+            if (std::regex_match(line, base_match, head_re))
+            {
+                ParseResult p;
+                p.head_line = base_match[1].str();
+                res.push_back(std::move(p));
+            }
+            else if (line[0] == '#')
+            {
+                res[res.size() - 1].comments.push_back(line);
+            }
+            else if (line.size() != 0)
+            {
+                res[res.size() - 1].diff.insert(line);
+            }
+        }
+        return res;
+    }
+
+    bool History::parse_comment_line(const std::string& line, UserRequest& req)
+    {
+        std::regex com_pat("#\\s*cmd:\\s*(.+)");
+        std::regex conda_v_pat("#\\s*conda version:\\s*(.+)");
+        std::regex spec_pat("#\\s*(\\w+)\\s*specs:\\s*(.+)?");
+        std::regex elems_pat("'([^',]+)'");
+        std::smatch rmatch;
+
+        if (std::regex_match(line, rmatch, com_pat))
+        {
+            req.cmd = rmatch[1].str();
+        }
+
+        else if (std::regex_match(line, rmatch, conda_v_pat))
+        {
+            req.conda_version = rmatch[1].str();
+        }
+        else if (std::regex_match(line, rmatch, spec_pat))
+        {
+            std::string action = rmatch[1].str();
+            std::string elems = rmatch[2].str();
+
+            std::cmatch ematch;
+            std::vector<std::string> pkg_specs;
+            const char* text_iter = elems.c_str();
+            while (std::regex_search(text_iter, (const char*) elems.c_str() + elems.size(), ematch, elems_pat))
+            {
+                pkg_specs.push_back(ematch[1].str());
+                text_iter += ematch[0].length();
+            }
+            if (action == "update" || action == "install" || action == "create")
+            {
+                req.update = std::move(pkg_specs);
+            }
+            else if (action == "remove" || action == "uninstall")
+            {
+                req.remove = std::move(pkg_specs);
+            }
+            else if (action == "neutered")
+            {
+                req.neutered = std::move(pkg_specs);
+            }
+        }
+        return true;
+    }
+
+    std::vector<History::UserRequest> History::get_user_requests()
+    {
+        std::vector<UserRequest> res;
+        for (const auto& el : parse())
+        {
+            UserRequest r;
+            r.date = el.head_line;
+            for (const auto& c : el.comments)
+            {
+                parse_comment_line(c, r);
+            }
+
+            for (const auto& x : el.diff)
+            {
+                if (x[0] == '-')
+                {
+                    r.unlink_dists.push_back(x);
+                }
+                else if (x[0] == '+')
+                {
+                    r.link_dists.push_back(x);
+                }
+            }
+            res.push_back(r);
+        }
+        // TODO add some stuff here regarding version of conda?
+        return res;
+    }
+
+    std::unordered_map<std::string, MatchSpec> History::get_requested_specs_map()
+    {
+        std::unordered_map<std::string, MatchSpec> map;
+
+        auto to_specs = [](const std::vector<std::string>& sv) {
+            std::vector<MatchSpec> v;
+            v.reserve(sv.size());
+            for (const auto& el : sv)
+            {
+                v.emplace_back(el);
+            }
+            return v;
+        };
+
+        for (const auto& request : get_user_requests())
+        {
+            auto remove_specs = to_specs(request.remove);
+            for (auto& spec : remove_specs)
+            {
+                map.erase(spec.name);
+            }
+            auto update_specs = to_specs(request.update);
+            for (auto& spec : update_specs)
+            {
+                map[spec.name] = spec;
+            }
+            auto neutered_specs = to_specs(request.neutered);
+            for (auto& spec : neutered_specs)
+            {
+                map[spec.name] = spec;
+            }
+        }
+
+        // TODO Add this back in once we merge the PrefixData PR!
+        // auto& current_records = m_prefix_data->records();
+        // for (auto it = map.begin(); it != map.end();)
+        // {
+        //     if (current_records.find(it->first) == current_records.end())
+        //     {
+        //         LOG_INFO << it->first << " not installed, removing from specs";
+        //         it = map.erase(it);
+        //     }
+        //     else
+        //     {
+        //         it++;
+        //     }
+        // }
+        return map;
+    }
+}


### PR DESCRIPTION
@marimeireles I had to rebase the PR because we pushed some of the files from the other PR to master already.

What's missing in this PR are functions to modify the history.

The history records all actions that conda / mamba did on a specific prefix such as installing or removing a package.

One needs to distinguish packages that are installed on **user** request (those are the "specs"), and just installed packages.

What we need now is to have a function where we can pass in new specs (packages that were asked to be installed, removed or neutered), and where we can give a list of newly installed and newly deleted packages and then write them out to the History file in the same format as conda does:

```
==> 2020-04-24 15:06:47 <==
# cmd: /home/wolfv/miniconda3/bin/mamba install pytorch -c defaults
# conda version: 4.8.3
+conda-forge/linux-64::ninja-1.10.0-hc9558a2_0
+defaults/linux-64::_pytorch_select-0.2-gpu_0
+defaults/linux-64::blas-1.0-mkl
+defaults/linux-64::cudatoolkit-10.1.243-h6bb024c_0
+defaults/linux-64::cudnn-7.6.5-cuda10.1_0
+defaults/linux-64::intel-openmp-2020.0-166
+defaults/linux-64::mkl-2020.0-166
+defaults/linux-64::mkl-service-2.3.0-py37he904b0f_0
+defaults/linux-64::pytorch-1.4.0-cuda101py37h02f0884_0
# update specs: ['pytorch']
```

The interface can probably look something like:

```
History
{
...

add_entry(const std::vector<std::string>& update_specs, const std::vector<std::string>& remove_specs, ..., )
{
}

}
```

