### PR TITLE
Refactored URLParser and added utility functions

### DIFF
--- a/include/url.hpp
+++ b/include/url.hpp
@@ -35,12 +35,23 @@ namespace mamba
 
     bool is_url(const std::string& url);
 
-    class URLParser
+    void split_anaconda_token(const std::string& url,
+                              std::string& cleaned_url,
+                              std::string& token);
+    
+    void split_scheme_auth_token(const std::string& url,
+                                 std::string& remaining_url,
+                                 std::string& scheme,
+                                 std::string& auth,
+                                 std::string& token);
+
+
+    class URLHandler
     {
     public:
     
-        URLParser(const std::string& url);
-        ~URLParser();
+        URLHandler(const std::string& url = "");
+        ~URLHandler();
 
         std::string url();
 
@@ -53,18 +64,33 @@ namespace mamba
         std::string fragment();
         std::string options();
 
+        std::string auth();
         std::string user();
         std::string password();
         std::string zoneid();
 
+        void set_scheme(const std::string& scheme);
+        void set_host(const std::string& host);
+        void set_path(const std::string& path);
+        void set_port(const std::string& port);
+
+        void set_query(const std::string& query);
+        void set_fragment(const std::string& fragment);
+        void set_options(const std::string& options);
+
+        void set_user(const std::string& user);
+        void set_password(const std::string& password);
+        void set_zoneid(const std::string& zoneid);
+
     private:
 
         std::string get_part(CURLUPart part);
+        void set_part(CURLUPart part, const std::string& s);
 
         std::string m_url;
         CURLU* m_handle;
+        bool m_scheme_set;
     };
-
 }
 
 #endif

--- a/src/url.cpp
+++ b/src/url.cpp
@@ -1,4 +1,8 @@
+#include <iostream>
+#include <regex>
+
 #include "url.hpp"
+#include "util.hpp"
 
 namespace mamba
 {
@@ -7,7 +11,7 @@ namespace mamba
         if (url.size() == 0) return false;
         try
         {
-            URLParser p(url); 
+            URLHandler p(url); 
             return p.scheme().size() != 0;
         }
         catch(...)
@@ -16,87 +20,192 @@ namespace mamba
         }
     }
 
-    URLParser::URLParser(const std::string& url)
+    void split_anaconda_token(const std::string& url,
+                              std::string& cleaned_url,
+                              std::string& token)
+    {
+        std::regex token_re("/t/([a-zA-Z0-9-]*)");
+        auto token_begin = std::sregex_iterator(url.begin(), url.end(), token_re);
+        if (token_begin != std::sregex_iterator())
+        {
+            token = token_begin->str().substr(3u);
+            cleaned_url = std::regex_replace(url, token_re, "", std::regex_constants::format_first_only);
+        }
+        else
+        {
+            token = "";
+            cleaned_url = url;
+        }
+        cleaned_url = rstrip(cleaned_url, "/");
+    }
+
+    void split_scheme_auth_token(const std::string& url,
+                                 std::string& remaining_url,
+                                 std::string& scheme,
+                                 std::string& auth,
+                                 std::string& token)
+    {
+        std::string cleaned_url;
+        split_anaconda_token(url, cleaned_url, token);
+        URLHandler handler(cleaned_url);
+        scheme = handler.scheme();
+        auth = handler.auth();
+        handler.set_scheme("");
+        handler.set_user("");
+        handler.set_password("");
+        remaining_url = handler.url();
+    }
+
+    URLHandler::URLHandler(const std::string& url)
         : m_url(url)
+        , m_scheme_set(url != "")
     {
         m_handle = curl_url(); /* get a handle to work with */ 
         if (!m_handle)
         {
             throw std::runtime_error("Could not initiate URL parser.");
         }
-        CURLUcode uc;
-        uc = curl_url_set(m_handle, CURLUPART_URL, url.c_str(), CURLU_NON_SUPPORT_SCHEME);
-        if (uc)
+        if (m_scheme_set)
         {
-            throw std::runtime_error("Could not set URL (code: " + std::to_string(uc) + ")");
+            CURLUcode uc;
+            uc = curl_url_set(m_handle, CURLUPART_URL, url.c_str(), CURLU_NON_SUPPORT_SCHEME);
+            if (uc)
+            {
+                throw std::runtime_error("Could not set URL (code: " + std::to_string(uc) + ")");
+            }
         }
     }
 
-    URLParser::~URLParser()
+    URLHandler::~URLHandler()
     {
         curl_url_cleanup(m_handle);
     }
 
-    std::string URLParser::url()
+    std::string URLHandler::url()
     {
-        return get_part(CURLUPART_URL);
+        std::string res = get_part(CURLUPART_URL);
+        if (!m_scheme_set)
+        {
+            res = res.substr(8);
+        }
+        return res;
     }
 
-    std::string URLParser::scheme()
+    std::string URLHandler::scheme()
     {
         return get_part(CURLUPART_SCHEME);
     }
 
-    std::string URLParser::host()
+    std::string URLHandler::host()
     {
         return get_part(CURLUPART_HOST);
     }
 
-    std::string URLParser::path()
+    std::string URLHandler::path()
     {
         return get_part(CURLUPART_PATH);
     }
 
-    std::string URLParser::port()
+    std::string URLHandler::port()
     {
         return get_part(CURLUPART_PORT);
     }
 
-    std::string URLParser::query()
+    std::string URLHandler::query()
     {
         return get_part(CURLUPART_QUERY);
     }
 
-    std::string URLParser::fragment()
+    std::string URLHandler::fragment()
     {
         return get_part(CURLUPART_FRAGMENT);
     }
 
-    std::string URLParser::options()
+    std::string URLHandler::options()
     {
         return get_part(CURLUPART_OPTIONS);
     }
 
-    std::string URLParser::user()
+    std::string URLHandler::auth()
+    {
+        std::string u = user();
+        std::string p = password();
+        return p != "" ? u + ':' + p : u;
+    }
+ 
+    std::string URLHandler::user()
     {
         return get_part(CURLUPART_USER);
     }
 
-    std::string URLParser::password()
+    std::string URLHandler::password()
     {
         return get_part(CURLUPART_PASSWORD);
     }
 
-    std::string URLParser::zoneid()
+    std::string URLHandler::zoneid()
     {
         return get_part(CURLUPART_ZONEID);
     }
 
+    void URLHandler::set_scheme(const std::string& scheme)
+    {
+        m_scheme_set = (scheme != "");
+        if (m_scheme_set)
+        {
+            set_part(CURLUPART_SCHEME, scheme);
+        }
+    }
 
-    std::string URLParser::get_part(CURLUPart part)
+    void URLHandler::set_host(const std::string& host)
+    {
+        set_part(CURLUPART_HOST, host);
+    }
+
+    void URLHandler::set_path(const std::string& path)
+    {
+        set_part(CURLUPART_PATH, path);
+    }
+
+    void URLHandler::set_port(const std::string& port)
+    {
+        set_part(CURLUPART_PORT, port);
+    }
+    
+    void URLHandler::set_query(const std::string& query)
+    {
+        set_part(CURLUPART_QUERY, query);
+    }
+
+    void URLHandler::set_fragment(const std::string& fragment)
+    {
+        set_part(CURLUPART_FRAGMENT, fragment);
+    }
+
+    void URLHandler::set_options(const std::string& options)
+    {
+        set_part(CURLUPART_OPTIONS, options);
+    }
+
+    void URLHandler::set_user(const std::string& user)
+    {
+        set_part(CURLUPART_USER, user);
+    }
+
+    void URLHandler::set_password(const std::string& password)
+    {
+        set_part(CURLUPART_PASSWORD, password);
+    }
+
+    void URLHandler::set_zoneid(const std::string& zoneid)
+    {
+        set_part(CURLUPART_ZONEID, zoneid);
+    }
+    
+    std::string URLHandler::get_part(CURLUPart part)
     {
         char* scheme;
-        auto rc = curl_url_get(m_handle, part, &scheme, 0);
+        auto rc = curl_url_get(m_handle, part, &scheme, m_scheme_set ? 0 : CURLU_DEFAULT_SCHEME);
         if (!rc)
         {
             std::string res(scheme);
@@ -106,6 +215,16 @@ namespace mamba
         else
         {
             throw std::runtime_error("Could not find SCHEME of url " + m_url);
+        }
+    }
+
+    void URLHandler::set_part(CURLUPart part, const std::string& s)
+    {
+        const char* data = s == "" ? nullptr : s.c_str();
+        auto rc = curl_url_set(m_handle, part, data, CURLU_NON_SUPPORT_SCHEME);
+        if (rc)
+        {
+            throw std::runtime_error("Could not set " + s + " in url " + m_url);
         }
     }
 } 

--- a/test/test_url.cpp
+++ b/test/test_url.cpp
@@ -7,13 +7,13 @@ namespace mamba
     TEST(url, parse)
     {
         {
-            URLParser m("http://mamba.org");
+            URLHandler m("http://mamba.org");
             EXPECT_EQ(m.scheme(), "http");
             EXPECT_EQ(m.path(), "/");
             EXPECT_EQ(m.host(), "mamba.org");
         }
         {
-            URLParser m("s3://userx123:üúßsajd@mamba.org");
+            URLHandler m("s3://userx123:üúßsajd@mamba.org");
             EXPECT_EQ(m.scheme(), "s3");
             EXPECT_EQ(m.path(), "/");
             EXPECT_EQ(m.host(), "mamba.org");
@@ -21,11 +21,69 @@ namespace mamba
             EXPECT_EQ(m.password(), "üúßsajd");
         }
         {
-            URLParser m("https://mamba🆒🔬.org/this/is/a/path/?query=123&xyz=3333");
+            URLHandler m("https://mamba🆒🔬.org/this/is/a/path/?query=123&xyz=3333");
             EXPECT_EQ(m.scheme(), "https");
             EXPECT_EQ(m.path(), "/this/is/a/path/");
             EXPECT_EQ(m.host(), "mamba🆒🔬.org");
             EXPECT_EQ(m.query(), "query=123&xyz=3333");
         }
+    }
+
+    TEST(url, split_ananconda_token)
+    {
+
+        std::string input, cleaned_url, token;
+        {
+            input = "https://1.2.3.4/t/tk-123-456/path";
+            split_anaconda_token(input, cleaned_url, token);
+            EXPECT_EQ(cleaned_url, "https://1.2.3.4/path");
+            EXPECT_EQ(token, "tk-123-456");
+        }
+
+        {
+            input = "https://1.2.3.4/t//path";
+            split_anaconda_token(input, cleaned_url, token);
+            EXPECT_EQ(cleaned_url, "https://1.2.3.4/path");
+            EXPECT_EQ(token, "");
+        }
+
+        {
+            input = "https://some.domain/api/t/tk-123-456/path";
+            split_anaconda_token(input, cleaned_url, token);
+            EXPECT_EQ(cleaned_url, "https://some.domain/api/path");
+            EXPECT_EQ(token, "tk-123-456");
+        }
+
+        {
+            input = "https://1.2.3.4/conda/t/tk-123-456/path";
+            split_anaconda_token(input, cleaned_url, token);
+            EXPECT_EQ(cleaned_url, "https://1.2.3.4/conda/path");
+            EXPECT_EQ(token, "tk-123-456");
+        }
+
+        {
+            input = "https://1.2.3.4/path";
+            split_anaconda_token(input, cleaned_url, token);
+            EXPECT_EQ(cleaned_url, "https://1.2.3.4/path");
+            EXPECT_EQ(token, "");
+        }
+
+        {
+            input = "https://10.2.3.4:8080/conda/t/tk-123-45";
+            split_anaconda_token(input, cleaned_url, token);
+            EXPECT_EQ(cleaned_url, "https://10.2.3.4:8080/conda");
+            EXPECT_EQ(token, "tk-123-45");
+        }
+    }
+
+    TEST(url, split_scheme_auth_token)
+    {
+        std::string input = "https://u:p@conda.io/t/x1029384756/more/path";
+        std::string remaining_url, scheme, auth, token;
+        split_scheme_auth_token(input, remaining_url, scheme, auth, token);
+        EXPECT_EQ(remaining_url, "conda.io/more/path");
+        EXPECT_EQ(scheme, "https");
+        EXPECT_EQ(auth, "u:p");
+        EXPECT_EQ(token, "x1029384756");
     }
 }


### PR DESCRIPTION
@wolfv it looks like it is not possible to erase the scheme part of an URL with libcurl (you get an error when you try to retrieve the full URL after), so I added some logic to manually remove the scheme part when that's needed.