### PR TITLE
Use conda compilers and conda cmake in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ conda install mamba -c conda-forge
 
 Make sure to have the following requirements in your conda environment:
 
-- `conda install pybind11 libsolv libarchive libcurl nlohmann_json pip -c conda-forge`
+- `conda install cmake compilers pybind11 libsolv libarchive libcurl nlohmann_json pip -c conda-forge`
 
 If you build mamba in a different environment than base, you must also install conda in
 that environment:


### PR DESCRIPTION
When you already use conda environments for building, also use their toolchain.