### PR TITLE
Use CMP0025

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,7 @@
 cmake_minimum_required (VERSION 2.8.11)
+if(POLICY CMP0025)
+  cmake_policy(SET CMP0025 NEW)
+endif()
 project (mamba)
 
 if (MSVC)


### PR DESCRIPTION
This was required to build on OSX with the conda `clang` in my environment. Otherwise cmake complained about `no known features for cxx compiler`.