### PR TITLE
More fixes of Channel C++ implementation

### DIFF
--- a/include/url.hpp
+++ b/include/url.hpp
@@ -53,6 +53,9 @@ namespace mamba
     bool is_path(const std::string& input);
     std::string path_to_url(const std::string& path);
 
+    template <class S, class... Args>
+    std::string join_url(const S& s, const Args&... args);
+
     class URLHandler
     {
     public:
@@ -104,6 +107,36 @@ namespace mamba
         CURLU* m_handle;
         bool m_has_scheme;
     };
+
+    namespace detail
+    {
+        inline std::string join_url_impl(std::string& s)
+        {
+            return s;
+        }
+
+        template <class S, class... Args>
+        inline std::string join_url_impl(std::string& s1, const S& s2, const Args&... args)
+        {
+            if (!s2.empty())
+            {
+                s1 += '/' + s2;
+            }
+            return join_url_impl(s1, args...);
+        }
+    }
+
+    inline std::string join_url()
+    {
+        return "";
+    }
+
+    template <class S, class... Args>
+    inline std::string join_url(const S& s, const Args&... args)
+    {
+        std::string res = s;
+        return detail::join_url_impl(res, args...);
+    }
 }
 
 #endif

--- a/src/channel.cpp
+++ b/src/channel.cpp
@@ -311,12 +311,12 @@ namespace mamba
         for (const auto& ca: custom_channels)
         {
             const Channel& channel = ca.second;
-            std::string test_url = channel.location() + '/' + channel.name();
+            std::string test_url = join_url(channel.location(), channel.name());
             if (starts_with(url, test_url)) // original code splits with '/' and compares tokens
             {
                 auto subname = std::string(strip(url.replace(0u, test_url.size(), ""), "/"));
                 return channel_configuration(channel.location(),
-                                             channel.name() + '/' + subname,
+                                             join_url(channel.name(), subname),
                                              scheme,
                                              channel.auth(),
                                              channel.token());

--- a/src/py_interface.cpp
+++ b/src/py_interface.cpp
@@ -11,6 +11,7 @@
 #include "subdirdata.hpp"
 #include "context.hpp"
 #include "channel.hpp"
+#include "url.hpp"
 
 namespace py = pybind11;
 
@@ -126,9 +127,11 @@ PYBIND11_MODULE(mamba_api, m) {
         .def_property_readonly("scheme", &Channel::scheme)
         .def_property_readonly("location", &Channel::location)
         .def_property_readonly("name", &Channel::name)
+        .def_property_readonly("platform", &Channel::platform)
         .def_property_readonly("subdir", &Channel::platform)
         .def_property_readonly("canonical_name", &Channel::canonical_name)
         .def("url", &Channel::url, py::arg("with_credentials") = true)
+        .def("__repr__", [](const Channel& c) { return join_url(c.name(), c.platform()); })
     ;
 
     m.attr("SOLVER_SOLVABLE") = SOLVER_SOLVABLE;

--- a/test/test_channel.cpp
+++ b/test/test_channel.cpp
@@ -44,6 +44,13 @@ namespace mamba
         EXPECT_EQ(c.location(), "conda.anaconda.org");
         EXPECT_EQ(c.name(), "conda-forge");
         EXPECT_EQ(c.platform(), "linux-64");
+
+        std::string value2 = "https://repo.anaconda.com/pkgs/main/linux-64";
+        Channel& c2 = make_channel(value2);
+        EXPECT_EQ(c2.scheme(), "https");
+        EXPECT_EQ(c2.location(), "repo.anaconda.com");
+        EXPECT_EQ(c2.name(), "pkgs/main");
+        EXPECT_EQ(c2.platform(), "linux-64");
     }
 }
 


### PR DESCRIPTION
With these fixes I could install xtensor from the conda-forge channel. I think we can plug this implementation behind the experimental flag. There is still work to do to handle spaces in URL.