### PR TITLE
Fix mamba env create with nodefaults

### DIFF
--- a/mamba/mamba_env.py
+++ b/mamba/mamba_env.py
@@ -39,7 +39,7 @@ def mamba_install(prefix, specs, args, env, *_, **kwargs):
         channel_urls.extend(context.channels)
     _channel_priority_map = prioritize_channels(channel_urls)
 
-    index = get_index(tuple(_channel_priority_map.keys()))
+    index = get_index(tuple(_channel_priority_map.keys()), prepend=False)
 
     channel_json = []
 


### PR DESCRIPTION
`get_index` prepended channels that might not be in the `channel_urls` list and thus also not in the `_channel_priority_map` list. Not sure how to write a unit test for this.

This fixes the following error:

```
# >>>>>>>>>>>>>>>>>>>>>> ERROR REPORT <<<<<<<<<<<<<<<<<<<<<<

    Traceback (most recent call last):
      File "/opt/conda/lib/python3.7/site-packages/conda/exceptions.py", line 1079, in __call__
        return func(*args, **kwargs)
      File "/opt/conda/lib/python3.7/site-packages/conda_env/cli/main.py", line 80, in do_call
        exit_code = getattr(module, func_name)(args, parser)
      File "/opt/conda/lib/python3.7/site-packages/conda_env/cli/main_create.py", line 111, in execute
        result[installer_type] = installer.install(prefix, pkg_specs, args, env)
      File "/opt/conda/lib/python3.7/site-packages/mamba/mamba_env.py", line 48, in mamba_install
        priority = len(_channel_priority_map) - _channel_priority_map[chan.url(with_credentials=True)][1]
    KeyError: '***/other-channel/linux-64'
```