### PR TITLE
add pip to repo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ project (mamba)
 if (MSVC)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /DNOMINMAX")
 else()
-    # set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
 endif()
 
 find_package(Threads REQUIRED)

--- a/include/context.hpp
+++ b/include/context.hpp
@@ -70,6 +70,9 @@ namespace mamba
         // a directory with cert files, or a cert file.
         std::string ssl_verify = "";
 
+        // Conda compat
+        bool add_pip_as_python_dependency = true;
+
         void set_verbosity(int lvl);
     
         std::string platform() const;

--- a/include/repo.hpp
+++ b/include/repo.hpp
@@ -18,6 +18,20 @@ extern "C"
 
 namespace mamba
 {
+    struct RepoMetadata
+    {
+        std::string url;
+        bool pip_added;
+        std::string etag;
+        std::string mod;
+    };
+
+    inline bool operator==(const RepoMetadata& lhs, const RepoMetadata& rhs)
+    {
+        return lhs.url == rhs.url && lhs.pip_added == rhs.pip_added &&
+               lhs.etag == rhs.etag && lhs.mod == rhs.mod;
+    }
+
     class MRepo
     {
     public:
@@ -25,12 +39,14 @@ namespace mamba
         MRepo(MPool& pool, const PrefixData& prefix_data);
         MRepo(MPool& pool, const std::string& name,
               const std::string& filename, const std::string& url);
+        MRepo(MPool& pool, const std::string& name, const fs::path& path, const RepoMetadata& meta);
         ~MRepo();
 
         void set_installed();
         void set_priority(int priority, int subpriority);
 
-        const char* name() const;
+        std::string name() const;
+        bool write() const;
         const std::string& url() const;
         Repo* repo();
         std::tuple<int, int> priority() const;
@@ -42,6 +58,8 @@ namespace mamba
 
         std::string m_json_file, m_solv_file;
         std::string m_url;
+
+        RepoMetadata m_metadata;
 
         Repo* m_repo;
     };

--- a/include/subdirdata.hpp
+++ b/include/subdirdata.hpp
@@ -8,6 +8,7 @@
 #include "nlohmann/json.hpp"
 
 #include "context.hpp"
+#include "repo.hpp"
 #include "util.hpp"
 #include "fetch.hpp"
 #include "output.hpp"
@@ -37,6 +38,8 @@ namespace mamba
         const std::string& name() const;
         bool finalize_transfer();
 
+        MRepo create_repo(MPool& pool);
+
     private:
 
         bool decompress();
@@ -58,6 +61,7 @@ namespace mamba
         std::string m_name;
         std::string m_json_fn;
         std::string m_solv_fn;
+        nlohmann::json m_mod_etag;
         std::unique_ptr<TemporaryFile> m_temp_file;
     };
 

--- a/mamba/utils.py
+++ b/mamba/utils.py
@@ -87,6 +87,7 @@ def init_api_context(use_mamba_experimental=False):
     api_ctx.connect_timeout_secs = int(round(context.remote_connect_timeout_secs))
     api_ctx.max_retries = context.remote_max_retries
     api_ctx.retry_backoff = context.remote_backoff_factor
+    api_ctx.add_pip_as_python_dependency = context.add_pip_as_python_dependency
 
 def to_package_record_from_subjson(channel, pkg, jsn_string):
     channel = channel

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -110,10 +110,10 @@ void install_specs(const std::vector<std::string>& specs)
     fs::path cache_dir = ctx.root_prefix / "pkgs" / "cache";
     fs::create_directories(cache_dir);
 
-    MSubdirData cfl("conda-forge",
+    MSubdirData cfl("conda-forge/linux-64",
                     "https://conda.anaconda.org/conda-forge/linux-64/repodata.json",
                     cache_dir / "cf_linux64.json");
-    MSubdirData cfn("conda-forge",
+    MSubdirData cfn("conda-forge/noarch",
                     "https://conda.anaconda.org/conda-forge/noarch/repodata.json",
                     cache_dir / "cf_noarch.json");
     cfl.load();
@@ -130,11 +130,11 @@ void install_specs(const std::vector<std::string>& specs)
     auto repo = MRepo(pool, prefix_data);
     repos.push_back(&repo);
 
-    MRepo cfl_r(pool, "conda-forge/linux-64", cfl.cache_path(), "https://conda.anaconda.org/conda-forge/linux-64/");
+    MRepo cfl_r = cfl.create_repo(pool);
     cfl_r.set_priority(0, 1);
     repos.push_back(&cfl_r);
 
-    MRepo cfl_n(pool, "conda-forge/noarch", cfn.cache_path(), "https://conda.anaconda.org/conda-forge/noarch/");
+    MRepo cfl_n = cfn.create_repo(pool);
     cfl_n.set_priority(0, 0);
     repos.push_back(&cfl_n);
 

--- a/src/py_interface.cpp
+++ b/src/py_interface.cpp
@@ -81,6 +81,7 @@ PYBIND11_MODULE(mamba_api, m) {
 
     py::class_<MSubdirData>(m, "SubdirData")
         .def(py::init<const std::string&, const std::string&, const std::string&>())
+        .def("create_repo", &MSubdirData::create_repo)
         .def("load", &MSubdirData::load)
         .def("loaded", &MSubdirData::loaded)
         .def("cache_path", &MSubdirData::cache_path)

--- a/src/py_interface.cpp
+++ b/src/py_interface.cpp
@@ -116,6 +116,7 @@ PYBIND11_MODULE(mamba_api, m) {
         .def_readwrite("retry_backoff", &Context::retry_backoff)
         .def_readwrite("read_timeout_secs", &Context::read_timeout_secs)
         .def_readwrite("connect_timeout_secs", &Context::connect_timeout_secs)
+        .def_readwrite("add_pip_as_python_dependency", &Context::add_pip_as_python_dependency)
         .def_readwrite("target_prefix", &Context::target_prefix)
         .def_readonly("sig_interrupt", &Context::sig_interrupt)
         .def("set_verbosity", &Context::set_verbosity)

--- a/src/repo.cpp
+++ b/src/repo.cpp
@@ -4,17 +4,43 @@
 
 extern "C"
 {
-    #include "common_write.c"
+    #include "solv/repo_write.h"
 }
+
+#define MAMBA_TOOL_VERSION "1.1"
+
+#define MAMBA_SOLV_VERSION MAMBA_TOOL_VERSION "_" LIBSOLV_VERSION_STRING
 
 namespace mamba
 {
-    MRepo::MRepo(MPool& pool, const std::string& name,
-                 const std::string& filename, const std::string& url)
+    const char* mamba_tool_version()
+    {
+        static char MTV[30];
+        MTV[0] = '\0';
+        strcat(MTV, MAMBA_TOOL_VERSION);
+        strcat(MTV, "_");
+        strcat(MTV, solv_version);
+        return MTV;
+    }
+
+    MRepo::MRepo(MPool& pool,
+                 const std::string& name,
+                 const fs::path& filename,
+                 const RepoMetadata& metadata)
+        : m_metadata(metadata)
+    {
+        m_url = rsplit(metadata.url, "/", 1)[0];
+        m_repo = repo_create(pool, m_url.c_str());
+        read_file(filename);
+    }
+
+    MRepo::MRepo(MPool& pool,
+                 const std::string& name,
+                 const std::string& filename,
+                 const std::string& url)
         : m_url(url)
     {
         m_repo = repo_create(pool, name.c_str());
-        // pool.add_repo(this);
         read_file(filename);
     }
 
@@ -91,9 +117,9 @@ namespace mamba
         m_repo->subpriority = subpriority;
     }
 
-    const char* MRepo::name() const
+    std::string MRepo::name() const
     {
-        return m_repo->name;
+        return m_repo->name ? m_repo->name : "";
     }
 
     const std::string& MRepo::url() const
@@ -144,29 +170,53 @@ namespace mamba
             LOG_INFO << "Attempt load from solv " << m_solv_file;
 
             int ret = repo_add_solv(m_repo, fp, 0);
-            auto* repodata = repo_last_repodata(m_repo);
-            if (!repodata)
+            if (ret != 0)
             {
-                LOG_ERROR << "Could not find valid repodata attached to solv file";
+                LOG_ERROR << "Could not load .solv file, falling back to JSON" << pool_errstr(m_repo->pool);
             }
             else
             {
-                const char* repo_tool_version = repodata_lookup_str(repodata, SOLVID_META, REPOSITORY_TOOLVERSION);
-                if (ret != 0)
+                auto* repodata = repo_last_repodata(m_repo);
+                if (!repodata)
                 {
-                    LOG_ERROR << "Could not load .solv file, falling back to JSON" << pool_errstr(m_repo->pool);
-                }
-                else if (repo_tool_version == nullptr || std::strcmp(mamba_tool_version(), repo_tool_version) != 0)
-                {
-                    LOG_INFO << "solv file was written with a previous version of libsolv or mamba " <<
-                                (repo_tool_version != nullptr ? repo_tool_version : "<NULL>") << ", updating it now!";
+                    LOG_ERROR << "Could not find valid repodata attached to solv file";
                 }
                 else
                 {
-                    LOG_INFO << "Loaded from solv " << m_solv_file;
-                    repo_internalize(m_repo);
-                    fclose(fp);
-                    return true;
+                    Id url_id = pool_str2id(m_repo->pool, "mamba:url", 1);
+                    Id etag_id = pool_str2id(m_repo->pool, "mamba:etag", 1);
+                    Id mod_id = pool_str2id(m_repo->pool, "mamba:mod", 1);
+                    Id pip_added_id = pool_str2id(m_repo->pool, "mamba:pip_added", 1);
+
+                    const char* url = repodata_lookup_str(repodata, SOLVID_META, url_id);
+                    int pip_added = repodata_lookup_num(repodata, SOLVID_META, pip_added_id, -1);
+                    const char* etag = repodata_lookup_str(repodata, SOLVID_META, etag_id);
+                    const char* mod = repodata_lookup_str(repodata, SOLVID_META, mod_id);
+                    const char* tool_version = repodata_lookup_str(repodata, SOLVID_META, REPOSITORY_TOOLVERSION);
+                    bool metadata_valid = !(!url || !etag || !mod || !tool_version || pip_added == -1);
+
+                    if (metadata_valid)
+                    {
+                        RepoMetadata read_metadata {
+                            url, pip_added == 1, etag, mod
+                        };
+                        metadata_valid = (read_metadata == m_metadata) && (std::strcmp(tool_version, mamba_tool_version()) == 0);
+                    }
+
+                    LOG_INFO << "Metadata from .solv is " << (metadata_valid ? "valid" : "NOT valid");
+
+                    if (!metadata_valid)
+                    {
+                        LOG_INFO << "solv file was written with a previous version of libsolv or mamba " <<
+                                    (tool_version != nullptr ? tool_version : "<NULL>") << ", updating it now!";
+                    }
+                    else
+                    {
+                        LOG_INFO << "Loaded from solv " << m_solv_file;
+                        repo_internalize(m_repo);
+                        fclose(fp);
+                        return true;
+                    }
                 }
             }
 
@@ -211,23 +261,53 @@ namespace mamba
 
         repo_internalize(m_repo);
 
-        // disabling solv caching for now on Windows
-        LOG_INFO << "creating solv: " << m_solv_file;
-
-        auto sfile = fopen(m_solv_file.c_str(), "wb");
-        if (sfile && name() != "installed")
+        if (name() != "installed")
         {
-            // TODO add error handling to tool_write
-            tool_write(m_repo, sfile);
-            fclose(sfile);
-        }
-        else
-        {
-            LOG_INFO << "could not create solv";
+            write();
         }
 
-        fclose(fp);
+        return true;
+    }
+
+    bool MRepo::write() const
+    {
+        Repodata* info;
+        Queue addedfileprovides;
+        Repowriter* writer;
+
+        LOG_INFO << "writing solv file: " << m_solv_file;
+
+        info = repo_add_repodata(m_repo, 0);  // add new repodata for our meta info
+        repodata_set_str(info, SOLVID_META, REPOSITORY_TOOLVERSION, mamba_tool_version());
+
+        Id url_id = pool_str2id(m_repo->pool, "mamba:url", 1);
+        Id pip_added_id = pool_str2id(m_repo->pool, "mamba:pip_added", 1);
+        Id etag_id = pool_str2id(m_repo->pool, "mamba:etag", 1);
+        Id mod_id = pool_str2id(m_repo->pool, "mamba:mod", 1);
+
+        repodata_set_str(info, SOLVID_META, url_id, m_metadata.url.c_str());
+        repodata_set_num(info, SOLVID_META, pip_added_id, m_metadata.pip_added);
+        repodata_set_str(info, SOLVID_META, etag_id, m_metadata.etag.c_str());
+        repodata_set_str(info, SOLVID_META, mod_id, m_metadata.mod.c_str());
+
+        auto solv_f = fopen(m_solv_file.c_str(), "wb");
+        repodata_internalize(info);
+
+        if (repo_write(m_repo, solv_f) != 0)
+        {
+            LOG_ERROR << "Failed to write .solv:" << pool_errstr(m_repo->pool);
+            return false;
+        }
+
+        if (fflush(solv_f))
+        {
+            LOG_ERROR << "Failed to flush .solv file.";
+            fclose(solv_f);
+            return false;
+        }
+
+        fclose(solv_f);
+        repodata_free(info); // delete meta info repodata again
         return true;
     }
 }
-


### PR DESCRIPTION
Fixes #85 

However, this means we need to store this in the repodata of the `.solv` file.

A good opportunity to get rid of the `common_write.c` and integrate it into our `repo.hpp` file.