### PR TITLE
Implemented create_cache_dir and cache_fn_url functions

### DIFF
--- a/include/package_cache.hpp
+++ b/include/package_cache.hpp
@@ -33,6 +33,7 @@ namespace mamba
         bool create_directory();
         void set_writable(Writable writable);
         Writable is_writable();
+        fs::path get_pkgs_dir() const;
 
         bool query(const PackageInfo& s);
 

--- a/include/subdirdata.hpp
+++ b/include/subdirdata.hpp
@@ -60,6 +60,15 @@ namespace mamba
         std::string m_solv_fn;
         std::unique_ptr<TemporaryFile> m_temp_file;
     };
+
+    // Contrary to conda original function, this one expects a full url
+    // (that is channel url + / + repodata_fn). It is not the
+    // responsibility of this function to decide whether it should
+    // concatenante base url and repodata depending on repodata value 
+    // and old behavior support.
+    std::string cache_fn_url(const std::string& url);
+    std::string create_cache_dir();
+
 }
 
 #endif // MAMBA_SUBDIRDATA_HPP

--- a/include/util.hpp
+++ b/include/util.hpp
@@ -1,11 +1,13 @@
 #ifndef MAMBA_UTIL_HPP
 #define MAMBA_UTIL_HPP
 
+#include <array>
+#include <iomanip>
+#include <random>
+#include <sstream>
 #include <stdexcept>
 #include <string_view>
 #include <string>
-#include <random>
-#include <array>
 
 #include "nlohmann/json.hpp"
 #include "thirdparty/filesystem.hpp"
@@ -206,6 +208,18 @@ namespace mamba
         result.reserve(len);
         concat_impl::concat_foreach(result, args...);
         return result;
+    }
+
+    template <class B>
+    inline std::string hex_string(const B& buffer)
+    {
+        std::ostringstream oss;
+        oss << std::hex;
+        for (std::size_t i = 0; i < buffer.size(); ++i)
+        {
+            oss << std::setw(2) << std::setfill('0') << static_cast<int>(buffer[i]);
+        }
+        return oss.str();
     }
 
     // get the value corresponding to a key in a JSON object and assign it to target

--- a/mamba/utils.py
+++ b/mamba/utils.py
@@ -34,13 +34,14 @@ def get_index(channel_urls=(), prepend=True, platform=None,
 
     sddata = []
     index = []
+
     for idx, url in enumerate(real_urls):
         channel = Channel(url)
 
         full_url = channel.url(with_credentials=True) + '/' + repodata_fn
         full_path_cache = os.path.join(
-            create_cache_dir(),
-            cache_fn_url(full_url, repodata_fn))
+            api.create_cache_dir(),
+            api.cache_fn_url(full_url))
 
         sd = api.SubdirData(channel.name + '/' + channel.subdir,
                             full_url,

--- a/src/package_cache.cpp
+++ b/src/package_cache.cpp
@@ -44,6 +44,11 @@ namespace mamba
         return m_writable;
     }
 
+    fs::path PackageCacheData::get_pkgs_dir() const
+    {
+        return m_pkgs_dir;
+    }
+
     PackageCacheData
     PackageCacheData::first_writable(const std::vector<fs::path>* pkgs_dirs)
     {

--- a/src/py_interface.cpp
+++ b/src/py_interface.cpp
@@ -85,6 +85,9 @@ PYBIND11_MODULE(mamba_api, m) {
         .def("loaded", &MSubdirData::loaded)
         .def("cache_path", &MSubdirData::cache_path)
     ;
+    
+    m.def("cache_fn_url", &cache_fn_url);
+    m.def("create_cache_dir", &create_cache_dir);
 
     py::class_<MultiDownloadTarget>(m, "DownloadTargetList")
         .def(py::init<>())

--- a/src/validate.cpp
+++ b/src/validate.cpp
@@ -1,8 +1,9 @@
 #include <iostream>
 #include "openssl/sha.h"
 #include "openssl/md5.h"
-#include "output.hpp"
 
+#include "output.hpp"
+#include "util.hpp"
 #include "validate.hpp"
 
 namespace validate
@@ -42,7 +43,7 @@ namespace validate
 
     std::string md5sum(const std::string& path)
     {
-        unsigned char hash[MD5_DIGEST_LENGTH];
+        std::array<unsigned char, MD5_DIGEST_LENGTH> hash;
 
         MD5_CTX md5;
         MD5_Init(&md5);
@@ -61,16 +62,9 @@ namespace validate
             MD5_Update(&md5, buffer.data(), count);
         }
 
-        MD5_Final(hash, &md5);
+        MD5_Final(hash.data(), &md5);
 
-        std::stringstream out;
-        out.fill('0');
-        out << std::hex;
-        for(int i = 0; i < MD5_DIGEST_LENGTH; i++) {
-            out << std::setw(2) << (int) hash[i];
-        }
-
-        return out.str();
+        return ::mamba::hex_string(hash);
     }
 
     bool sha256(const std::string& path, const std::string& validation)


### PR DESCRIPTION
Notice that this requires to set `MAMBA_ROOT_PREFIX` to `CONDA_PREFIX` to avoid creating an additional `pkgs` subdir. Also I wonder if `MAMBA_ROOT_PREFIX` should be renamed in `MAMBA_PREFIX`, because the first one seems to design the root environment. Or the value of `Context::pkgs_dir` should be change to something else.